### PR TITLE
allow #applications to return Collection instance, retry on 429, 5xx

### DIFF
--- a/greenhouse_io.gemspec
+++ b/greenhouse_io.gemspec
@@ -18,7 +18,11 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.add_runtime_dependency('activesupport')
+  spec.add_runtime_dependency('hashie')
   spec.add_runtime_dependency('httmultiparty', '~> 0.3.16')
+  spec.add_runtime_dependency('link-header-parser')
+  spec.add_runtime_dependency('retriable')
   spec.required_ruby_version = '>= 2.6.6'
 
   spec.add_development_dependency "bundler", "~> 1.3"

--- a/lib/greenhouse_io/api/application.rb
+++ b/lib/greenhouse_io/api/application.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require 'greenhouse_io/api/resource'
+
+module GreenhouseIo
+  class Application < Resource
+  end
+end

--- a/lib/greenhouse_io/api/application_collection.rb
+++ b/lib/greenhouse_io/api/application_collection.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'greenhouse_io/api/application'
 require 'greenhouse_io/api/resource_collection'
 
 module GreenhouseIo

--- a/lib/greenhouse_io/api/application_collection.rb
+++ b/lib/greenhouse_io/api/application_collection.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'greenhouse_io/api/resource_collection'
+
+module GreenhouseIo
+  class ApplicationCollection < ResourceCollection
+    def initialize(*args, **kw_args)
+      kw_args.merge!(resource_class: Application)
+      super
+    end
+  end
+end

--- a/lib/greenhouse_io/api/resource.rb
+++ b/lib/greenhouse_io/api/resource.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'hashie'
+
+module GreenhouseIo
+  class Resource
+    def initialize(source_hash = {})
+      self.mash = Hashie::Mash.new(source_hash)
+    end
+
+    def method_missing(method, *args, &block)
+      return mash.public_send(method, *args, &block) if mash.respond_to?(method)
+
+      super
+    end
+
+    def respond_to_missing?(method, __include_private = false)
+      mash.respond_to?(method) || super
+    end
+
+    private
+
+    attr_accessor :mash
+  end
+end

--- a/lib/greenhouse_io/api/resource_collection.rb
+++ b/lib/greenhouse_io/api/resource_collection.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'greenhouse_io/api/application'
+
+require 'active_support/core_ext/string/inflections'
+require 'link-header-parser'
+
+module GreenhouseIo
+  class ResourceCollection
+    include Enumerable
+
+    attr_accessor :client, :query_params, :resource_class
+
+    def initialize(client:, query_params: {}, resource_class:)
+      self.client             = client
+      self.query_params       = query_params
+      self.resource_class     = resource_class # e.g. GreenhouseIo::Application
+      self.hydrated_resources = []
+    end
+
+    def each
+      return enum_for(:each) unless block_given?
+
+      i = 0
+      loop do
+        if hydrated_resources.length == i
+          num_added_resources = request_next_page!
+          break if num_added_resources.zero?
+        end
+
+        yield hydrated_resources[i]
+        i += 1
+      end
+    end
+
+    private
+
+    attr_accessor :hydrated_resources, :next_page_url, :all_pages_requested
+
+    # returns # of new resources
+    def request_next_page!
+      return 0 if all_pages_requested?
+
+      # TODO: have lower-level methods (e.g. #get_from_harvest_api) implement retries
+      resp_arr = client.with_retries do
+        if next_page_url.present?
+          client.get_from_harvest_api(next_page_url)
+        else
+          # e.g. client.applications(nil, query_params)
+          client.public_send(resource_class.name.demodulize.tableize, nil, query_params)
+        end
+      end
+
+      links = LinkHeaderParser.parse(client.link.to_s, base: client.class.base_uri)
+      self.next_page_url       = links.find { |link| link.relation_types == ['next'] }&.target_uri
+      self.all_pages_requested = next_page_url.nil?
+
+      # e.g. [...].map { |resource_hash| GreenhouseIo::Application.new(resource_hash) }
+      hydrated_resources.push(*resp_arr.map { |resource_hash| resource_class.new(resource_hash) })
+
+      resp_arr.length
+    end
+
+    def all_pages_requested?
+      !!all_pages_requested
+    end
+  end
+end

--- a/lib/greenhouse_io/api/resource_collection.rb
+++ b/lib/greenhouse_io/api/resource_collection.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'greenhouse_io/api/application'
-
 require 'active_support/core_ext/string/inflections'
 require 'link-header-parser'
 

--- a/spec/fixtures/cassettes/GreenhouseIo_Client/given_an_instance_of_GreenhouseIo_Client/_applications/given_a_hash_as_only_argument/iterates_by_utilizing_pagination.yml
+++ b/spec/fixtures/cassettes/GreenhouseIo_Client/given_an_instance_of_GreenhouseIo_Client/_applications/given_a_hash_as_only_argument/iterates_by_utilizing_pagination.yml
@@ -1,0 +1,110 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://harvest.greenhouse.io/v1/applications?job_id=4737402002&per_page=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Basic <AUTH_VALUE>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 25 Feb 2021 22:16:25 GMT
+      Content-Type:
+      - application/json;charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept-Encoding
+      Link:
+      - <https://harvest.greenhouse.io/v1/applications?job_id=4737402002&page=2&per_page=1>;
+        rel="next",<https://harvest.greenhouse.io/v1/applications?job_id=4737402002&page=5&per_page=1>;
+        rel="last"
+      Status:
+      - 200 OK
+      X-Content-Type-Options:
+      - nosniff
+      X-Ratelimit-Limit:
+      - '50'
+      X-Ratelimit-Remaining:
+      - '48'
+      X-Request-Id:
+      - 8b6454698b998af3356de25131962877
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"status":"active","source":null,"rejection_reason":null,"rejection_details":null,"rejected_at":null,"prospective_office":null,"prospective_department":null,"prospect_detail":{"prospect_stage":null,"prospect_pool":null,"prospect_owner":null},"prospect":false,"location":null,"last_activity_at":"2021-02-25T19:37:22.563Z","jobs":[{"name":"Space
+        Explorer","id":4737402002}],"id":75692480002,"current_stage":{"name":"Phone
+        Interview","id":9621587002},"credited_to":{"name":"Greenhouse Admin","last_name":"Admin","id":4173306002,"first_name":"Greenhouse","employee_id":null},"candidate_id":68601968002,"attachments":[],"applied_at":"2020-12-30T18:25:48.510Z","answers":[]}]'
+    http_version: 
+  recorded_at: Thu, 25 Feb 2021 22:16:25 GMT
+- request:
+    method: get
+    uri: https://harvest.greenhouse.io/v1/applications?job_id=4737402002&page=2&per_page=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Basic <AUTH_VALUE>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 25 Feb 2021 22:16:25 GMT
+      Content-Type:
+      - application/json;charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept-Encoding
+      Link:
+      - <https://harvest.greenhouse.io/v1/applications?job_id=4737402002&page=3&per_page=1>;
+        rel="next",<https://harvest.greenhouse.io/v1/applications?job_id=4737402002&page=1&per_page=1>;
+        rel="prev",<https://harvest.greenhouse.io/v1/applications?job_id=4737402002&page=5&per_page=1>;
+        rel="last"
+      Status:
+      - 200 OK
+      X-Content-Type-Options:
+      - nosniff
+      X-Ratelimit-Limit:
+      - '50'
+      X-Ratelimit-Remaining:
+      - '47'
+      X-Request-Id:
+      - e087bdbeb2328bb150d696bb7605e196
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"status":"active","source":null,"rejection_reason":null,"rejection_details":null,"rejected_at":null,"prospective_office":null,"prospective_department":null,"prospect_detail":{"prospect_stage":null,"prospect_pool":null,"prospect_owner":null},"prospect":false,"location":null,"last_activity_at":"2021-02-25T19:37:15.257Z","jobs":[{"name":"Space
+        Explorer","id":4737402002}],"id":76347984002,"current_stage":{"name":"Phone
+        Interview","id":9621587002},"credited_to":{"name":"Greenhouse Admin","last_name":"Admin","id":4173306002,"first_name":"Greenhouse","employee_id":null},"candidate_id":69210188002,"attachments":[],"applied_at":"2021-01-08T03:43:11.489Z","answers":[]}]'
+    http_version: 
+  recorded_at: Thu, 25 Feb 2021 22:16:25 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/cassettes/GreenhouseIo_Client/given_an_instance_of_GreenhouseIo_Client/_applications/given_a_hash_as_only_argument/returns_application_details.yml
+++ b/spec/fixtures/cassettes/GreenhouseIo_Client/given_an_instance_of_GreenhouseIo_Client/_applications/given_a_hash_as_only_argument/returns_application_details.yml
@@ -1,0 +1,56 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://harvest.greenhouse.io/v1/applications?job_id=4737402002&per_page=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Basic <AUTH_VALUE>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 25 Feb 2021 22:16:25 GMT
+      Content-Type:
+      - application/json;charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept-Encoding
+      Link:
+      - <https://harvest.greenhouse.io/v1/applications?job_id=4737402002&page=2&per_page=1>;
+        rel="next",<https://harvest.greenhouse.io/v1/applications?job_id=4737402002&page=5&per_page=1>;
+        rel="last"
+      Status:
+      - 200 OK
+      X-Content-Type-Options:
+      - nosniff
+      X-Ratelimit-Limit:
+      - '50'
+      X-Ratelimit-Remaining:
+      - '49'
+      X-Request-Id:
+      - 1303e83e66e859c559a15a869f0f2b99
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"status":"active","source":null,"rejection_reason":null,"rejection_details":null,"rejected_at":null,"prospective_office":null,"prospective_department":null,"prospect_detail":{"prospect_stage":null,"prospect_pool":null,"prospect_owner":null},"prospect":false,"location":null,"last_activity_at":"2021-02-25T19:37:22.563Z","jobs":[{"name":"Space
+        Explorer","id":4737402002}],"id":75692480002,"current_stage":{"name":"Phone
+        Interview","id":9621587002},"credited_to":{"name":"Greenhouse Admin","last_name":"Admin","id":4173306002,"first_name":"Greenhouse","employee_id":null},"candidate_id":68601968002,"attachments":[],"applied_at":"2020-12-30T18:25:48.510Z","answers":[]}]'
+    http_version: 
+  recorded_at: Thu, 25 Feb 2021 22:16:25 GMT
+recorded_with: VCR 3.0.3

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,7 +11,8 @@ VCR.configure do |config|
   config.cassette_library_dir = 'spec/fixtures/cassettes'
   config.hook_into :webmock
   config.ignore_hosts 'codeclimate.com'
-  config.filter_sensitive_data('<API_TOKEN>') { ENV['API_TOKEN'] }
+  config.filter_sensitive_data('<API_TOKEN>')  { ENV['API_TOKEN'] }
+  config.filter_sensitive_data('<AUTH_VALUE>') { Base64.encode64("#{ENV['API_TOKEN']}:").chomp }
   config.configure_rspec_metadata!
 end
 


### PR DESCRIPTION
- when first arg to #applications is a hash, an ApplicationCollection object will be returned rather than a simple Array of Hashes
- Iterating over Collection objects will paginate automatically & lazily
- Requests from Collection objects (inc. first page req) will be retried if 429 / 5xx errors encountered
- This commit should not change existing functionality, but illuminates the path forward for this gem