### PR TITLE
Add #each_page to ResourceCollection

### DIFF
--- a/lib/greenhouse_io/api/resource_collection.rb
+++ b/lib/greenhouse_io/api/resource_collection.rb
@@ -23,6 +23,25 @@ module GreenhouseIo
       self.resource_class     = resource_class # e.g. GreenhouseIo::Application
       self.lazy_paginators    = [LazyPaginator.new(resource_collection: self, query_params: query_params)]
       self.hydrated_resources = []
+      self.hydrated_pages     = []
+    end
+
+    def each_page
+      return enum_for(:each_page) unless block_given?
+
+      i = 0
+      lazy_paginators.each do |lazy_paginator|
+        lazy_paginator.each_page do |page|
+          hydrated_pages.push(page) if hydrated_pages.length == i
+          hydrated_resources.push(*page.contents)
+          yield page
+          i += 1
+        end
+      end
+
+      self.all_resources_hydrated = true
+
+      hydrated_pages
     end
 
     def each
@@ -78,7 +97,7 @@ module GreenhouseIo
 
     protected
 
-    attr_accessor :lazy_paginators, :hydrated_resources, :all_resources_hydrated
+    attr_accessor :lazy_paginators, :hydrated_resources, :hydrated_pages, :all_resources_hydrated
 
     def all_resources_hydrated?
       !!all_resources_hydrated

--- a/lib/greenhouse_io/api/resource_collection/page.rb
+++ b/lib/greenhouse_io/api/resource_collection/page.rb
@@ -1,0 +1,31 @@
+module GreenhouseIo
+  class ResourceCollection
+    class Page
+      include Enumerable
+
+      attr_reader :next_page_url, :contents
+
+      def initialize(contents, next_page_url: nil)
+        @next_page_url = next_page_url
+        @contents = contents
+      end
+
+      def each
+        return enum_for(:each) unless block_given?
+        contents.each { |item| yield item }
+      end
+
+      def method_missing(method_name, *arguments, &block)
+        if contents.respond_to?(method_name, false)
+          contents.send(method_name, *arguments, &block)
+        else
+          super
+        end
+      end
+
+      def respond_to_missing?(method_name, include_private = false)
+        contents.respond_to?(method_name, include_private)
+      end
+    end
+  end
+end


### PR DESCRIPTION
each_page is similar to invoking each, except yields a page object
which is a collection of resources retrieved in a single API request
from the endpoint, along with a URL to the next page of results.

This allows consuming code to have more visibility into the pagination
process, for example to store the next page link in order to resume
pagination from there on error.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] Schema changes (if applicable) will play nicely with "rolling" deploy mechanism
- [ ] All UX vectors have been considered (desktop app, Chrome extension, responsive view)
- [ ] The code changed/added does not introduce security vulnerabilities

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] At least one other engineer confirms that schema changes (if applicable) will play nicely with "rolling" deploy mechanism
- [ ] At least one other engineer confirms that all UX vectors have been considered (desktop app, Chrome extension, responsive view)
- [ ] At least one other engineer has confirmed that the code changed/added will not introduce security vulnerabilities
- [ ] Issue from task tracker has a link to this pull request
