### PR TITLE
correct HTTP 429 retry behavior :grimacing:

### DIFF
--- a/lib/greenhouse_io/api/resource_collection/lazy_paginator.rb
+++ b/lib/greenhouse_io/api/resource_collection/lazy_paginator.rb
@@ -70,8 +70,8 @@ module GreenhouseIo
             client.get_from_harvest_api(next_page_url)
           else
             # If the id is part of the params, bring it out and append to URL
-            id = query_params.delete(:id)
-            client.get_from_harvest_api("#{resource_class::ENDPOINT}#{client.path_id(id)}", query_params)
+            ending = client.path_id(query_params[:id])
+            client.get_from_harvest_api("#{resource_class::ENDPOINT}#{ending}", query_params.except(:id))
           end
         end
 


### PR DESCRIPTION
In cats I'm simulating greenhouse giving a 429 and my tests revealed that retries are broken and maybe doing bad things. I dug up this line that looks to be mutating a shared `query_params` object by calling `.delete(:id)`.

This spec in my branch expected retries for the ID you see, but instead it hit bare `/jobs`:
```
GET https://harvest.greenhouse.io/v1/jobs/123892 ... was made 1 time
GET https://harvest.greenhouse.io/v1/jobs ... was made 2 times
```

Production-wise, I'm thinking that most of the time, fast retries of 429s hopefully got 429 too, so our logic error here had no effect. If the fast retries got lucky and were able to hit `/<resource>`, I am unsure of the implications downstream. Hopefully not much in cats, and I'm very unsure about this gem's usage in in go.grayscale.