### PR TITLE
remove 429s from fast-retry exception list

### DIFF
--- a/lib/greenhouse_io/api/client.rb
+++ b/lib/greenhouse_io/api/client.rb
@@ -12,8 +12,8 @@ module GreenhouseIo
     include HTTMultiParty
     include GreenhouseIo::API
 
+    # error cases that this gem will fast-fire retry
     RETRIABLE_ERRORS_REGEXP = /\A
-      429 | # rate-limiting
       5\d\d # 5xx errors
     \z/x.freeze
 

--- a/spec/greenhouse_io/api/client_spec.rb
+++ b/spec/greenhouse_io/api/client_spec.rb
@@ -197,15 +197,6 @@ describe GreenhouseIo::Client do
             allow(GreenhouseIo::Client).to receive(:get).and_return(double('success?': false, headers: {}, code: code))
           end
 
-          context 'when rate-limiting encountered' do
-            let(:code) { 429 }
-
-            it 'retries' do
-              expect(@client).to(receive(:get_response)).thrice.and_call_original
-              suppress(GreenhouseIo::Error) { candidates.first }
-            end
-          end
-
           context 'when 5xx encountered' do
             let(:code) { 500 }
 
@@ -396,15 +387,6 @@ describe GreenhouseIo::Client do
         context do
           before(:each) do
             allow(GreenhouseIo::Client).to receive(:get).and_return(double('success?': false, headers: {}, code: code))
-          end
-
-          context 'when rate-limiting encountered' do
-            let(:code) { 429 }
-
-            it 'retries' do
-              expect(@client).to(receive(:get_response)).thrice.and_call_original
-              suppress(GreenhouseIo::Error) { applications.first }
-            end
           end
 
           context 'when 5xx encountered' do
@@ -613,13 +595,6 @@ describe GreenhouseIo::Client do
         context do
           before(:each) do
             allow(GreenhouseIo::Client).to receive(:get).and_return(double('success?': false, headers: {}, code: code))
-          end
-          context 'when rate-limiting encountered' do
-            let(:code) { 429 }
-            it 'retries' do
-              expect(@client).to(receive(:get_response)).thrice.and_call_original
-              suppress(GreenhouseIo::Error) { jobs.first }
-            end
           end
           context 'when 5xx encountered' do
             let(:code) { 500 }


### PR DESCRIPTION
This is opinionated: When the API tells us, "you are at your rate limit," we should not immediately do the same request again. Some polite retry logic is underway elsewhere and it hinges on decisions/context outside of this gem. So we still care about retrying this case, but other context is coming into play, muddying things up unavoidably!