### PR TITLE
"dry" up hydrated resources by default

### DIFF
--- a/lib/greenhouse_io/api/resource_collection.rb
+++ b/lib/greenhouse_io/api/resource_collection.rb
@@ -16,16 +16,16 @@ module GreenhouseIo
   class ResourceCollection
     include Enumerable
 
-    attr_accessor :client, :resource_class
+    attr_accessor :client, :resource_class, :dehydrate_after_iteration
 
-    # @param dry [Boolean] When true, we try to keep only `:dried` around in the hydration arrays
-    def initialize(client:, query_params: {}, resource_class:, dry: true)
+    # @param dehydrate_after_iteration [Boolean] When true, we try to keep only `:dehydrated` around in the hydration arrays
+    def initialize(client:, query_params: {}, resource_class:, dehydrate_after_iteration: true)
       self.client             = client
       self.resource_class     = resource_class # e.g. GreenhouseIo::Application
       self.lazy_paginators    = [LazyPaginator.new(resource_collection: self, query_params: query_params)]
       self.hydrated_resources = []
       self.hydrated_pages     = []
-      @dry = dry
+      self.dehydrate_after_iteration = dehydrate_after_iteration
     end
 
     def each_page
@@ -52,7 +52,7 @@ module GreenhouseIo
       i = 0
       lazy_paginators.each do |lazy_paginator|
         lazy_paginator.each do |resource|
-          to_store = @dry ? :dried : resource
+          to_store = dehydrate_after_iteration ? :dehydrated : resource
           hydrated_resources << to_store if hydrated_resources.length == i
           yield resource
           i += 1

--- a/lib/greenhouse_io/api/resource_collection.rb
+++ b/lib/greenhouse_io/api/resource_collection.rb
@@ -18,12 +18,14 @@ module GreenhouseIo
 
     attr_accessor :client, :resource_class
 
-    def initialize(client:, query_params: {}, resource_class:)
+    # @param dry [Boolean] When true, we try to keep only `:dried` around in the hydration arrays
+    def initialize(client:, query_params: {}, resource_class:, dry: true)
       self.client             = client
       self.resource_class     = resource_class # e.g. GreenhouseIo::Application
       self.lazy_paginators    = [LazyPaginator.new(resource_collection: self, query_params: query_params)]
       self.hydrated_resources = []
       self.hydrated_pages     = []
+      @dry = dry
     end
 
     def each_page
@@ -50,7 +52,8 @@ module GreenhouseIo
       i = 0
       lazy_paginators.each do |lazy_paginator|
         lazy_paginator.each do |resource|
-          hydrated_resources << resource if hydrated_resources.length == i
+          to_store = @dry ? :dried : resource
+          hydrated_resources << to_store if hydrated_resources.length == i
           yield resource
           i += 1
         end

--- a/lib/greenhouse_io/api/resource_collection/lazy_paginator.rb
+++ b/lib/greenhouse_io/api/resource_collection/lazy_paginator.rb
@@ -12,17 +12,17 @@ module GreenhouseIo
     class LazyPaginator
       include Enumerable
 
-      attr_accessor :resource_collection, :query_params
+      attr_accessor :resource_collection, :query_params, :dehydrate_after_iteration
 
       delegate :client, :resource_class, to: :resource_collection
 
-      # @param dry [Boolean] When true, we try to keep only `:dried` around in the hydration arrays
-      def initialize(resource_collection:, query_params:, dry: true)
+      # @param dehydrate_after_iteration [Boolean] When true, we try to keep only `:dehydrated` around in the hydration arrays
+      def initialize(resource_collection:, query_params:, dehydrate_after_iteration: true)
         self.resource_collection = resource_collection
         self.query_params        = query_params
         self.hydrated_resources  = []
         self.hydrated_pages      = []
-        @dry = dry
+        self.dehydrate_after_iteration = dehydrate_after_iteration
       end
 
       def each_page
@@ -52,7 +52,7 @@ module GreenhouseIo
           end
 
           yield hydrated_resources[i]
-          hydrated_resources[i] = :dried if @dry
+          hydrated_resources[i] = :dehydrated if dehydrate_after_iteration
           i += 1
         end
 
@@ -92,7 +92,8 @@ module GreenhouseIo
         # e.g. [...].map { |resource_hash| GreenhouseIo::Application.new(resource_hash) }
         results = resp_arr.map { |resource_hash| resource_class.new(resource_hash) }
         hydrated_resources.push(*results)
-        hydrated_pages.push(Page.new(results, dry: @dry, next_page_url: next_page_url))
+        new_page = Page.new(results, dehydrate_after_iteration: dehydrate_after_iteration, next_page_url: next_page_url)
+        hydrated_pages.push(new_page)
 
         resp_arr.length
       end

--- a/lib/greenhouse_io/api/resource_collection/page.rb
+++ b/lib/greenhouse_io/api/resource_collection/page.rb
@@ -5,14 +5,18 @@ module GreenhouseIo
 
       attr_reader :next_page_url, :contents
 
-      def initialize(contents, next_page_url: nil)
+      def initialize(contents, next_page_url: nil, dry: true)
         @next_page_url = next_page_url
         @contents = contents
+        @dry = dry
       end
 
       def each
         return enum_for(:each) unless block_given?
-        contents.each { |item| yield item }
+        contents.map! do |item|
+          yield item
+          @dry ? :dried : item
+        end
       end
 
       def method_missing(method_name, *arguments, &block)

--- a/lib/greenhouse_io/api/resource_collection/page.rb
+++ b/lib/greenhouse_io/api/resource_collection/page.rb
@@ -5,17 +5,17 @@ module GreenhouseIo
 
       attr_reader :next_page_url, :contents
 
-      def initialize(contents, next_page_url: nil, dry: true)
+      def initialize(contents, next_page_url: nil, dehydrate_after_iteration: true)
         @next_page_url = next_page_url
         @contents = contents
-        @dry = dry
+        @dehydrate_after_iteration = dehydrate_after_iteration
       end
 
       def each
         return enum_for(:each) unless block_given?
         contents.map! do |item|
           yield item
-          @dry ? :dried : item
+          @dehydrate_after_iteration ? :dehydrated : item
         end
       end
 

--- a/lib/greenhouse_io/version.rb
+++ b/lib/greenhouse_io/version.rb
@@ -1,3 +1,3 @@
 module GreenhouseIo
-  VERSION = "3.1.0-grayscale"
+  VERSION = "3.2.2-grayscale"
 end

--- a/spec/greenhouse_io/api/candidate_collection_spec.rb
+++ b/spec/greenhouse_io/api/candidate_collection_spec.rb
@@ -37,4 +37,17 @@ RSpec.describe GreenhouseIo::CandidateCollection do
     expect(pages.length).to eq(3)
     expect(all.length).to eq(pages.map(&:count).sum)
   end
+
+  it 'blanks out records when .each is used' do
+    all = candidates.each.to_a
+    expect(all[0]).to be_a(GreenhouseIo::Candidate)
+    expect(candidates.count {|i| i == :dried }).to eq candidates.count
+  end
+
+  it 'blanks out pages when .each is called' do
+    all = candidates.each_page.to_a
+    expect(all[0][0]).to be_a(GreenhouseIo::Candidate)
+    all[0].each {}
+    expect(all[0][0]).to eq :dried
+  end
 end

--- a/spec/greenhouse_io/api/candidate_collection_spec.rb
+++ b/spec/greenhouse_io/api/candidate_collection_spec.rb
@@ -41,13 +41,13 @@ RSpec.describe GreenhouseIo::CandidateCollection do
   it 'blanks out records when .each is used' do
     all = candidates.each.to_a
     expect(all[0]).to be_a(GreenhouseIo::Candidate)
-    expect(candidates.count {|i| i == :dried }).to eq candidates.count
+    expect(candidates.count {|i| i == :dehydrated }).to eq candidates.count
   end
 
   it 'blanks out pages when .each is called' do
     all = candidates.each_page.to_a
     expect(all[0][0]).to be_a(GreenhouseIo::Candidate)
     all[0].each {}
-    expect(all[0][0]).to eq :dried
+    expect(all[0][0]).to eq :dehydrated
   end
 end


### PR DESCRIPTION
- taking another path to solve https://app.shortcut.com/grayscale/story/8428/apply-memory-savings-changes-to-greenhouse-client-gem

This ended up much quicker than the alternative "just keep a single page around" I implemented elsewhere. In the gem we have two `include Enumerable` classes meshed together here that are both hydrating arrays.

This will break any enum usage that expects actual records in hydrated arrays. It pretty much only keeps `.count` (with _no arguments_) accurate. At least I would be very surprised if I couldn't run normal methods in a `.count { |record| record.method }` situation.