### PR TITLE
ability to provide /job_applications/[id]/scheduled_interviews endpoint to LazyPaginators

### DIFF
--- a/lib/greenhouse_io/api/application.rb
+++ b/lib/greenhouse_io/api/application.rb
@@ -4,6 +4,6 @@ require 'greenhouse_io/api/resource'
 
 module GreenhouseIo
   class Application < Resource
-    ENDPOINT = "/applications"
+    DEFAULT_ENDPOINT = "/applications"
   end
 end

--- a/lib/greenhouse_io/api/candidate.rb
+++ b/lib/greenhouse_io/api/candidate.rb
@@ -4,6 +4,6 @@ require 'greenhouse_io/api/resource'
 
 module GreenhouseIo
   class Candidate < Resource
-    ENDPOINT = "/candidates"
+    DEFAULT_ENDPOINT = "/candidates"
   end
 end

--- a/lib/greenhouse_io/api/client.rb
+++ b/lib/greenhouse_io/api/client.rb
@@ -30,7 +30,8 @@ module GreenhouseIo
     end
 
     def offers(id = nil, options = {})
-      get_from_harvest_api "/offers#{path_id(id)}", normalize_params(options)
+      _kw_args, params = normalize_options(options)
+      get_from_harvest_api "/offers#{path_id(id)}", params
     end
 
     def departments(id = nil, options = {})
@@ -38,7 +39,8 @@ module GreenhouseIo
     end
 
     def candidates(options = {})
-      get_resource GreenhouseIo::CandidateCollection, normalize_params(options)
+      kw_args, params = normalize_options(options)
+      get_resource GreenhouseIo::CandidateCollection, params, **kw_args
     end
 
     def activity_feed(id, options = {})
@@ -70,11 +72,13 @@ module GreenhouseIo
     end
 
     def applications(options = {})
-      get_resource GreenhouseIo::ApplicationCollection, normalize_params(options)
+      kw_args, params = normalize_options(options)
+      get_resource GreenhouseIo::ApplicationCollection, params, **kw_args
     end
 
     def offers_for_application(id, options = {})
-      get_from_harvest_api "/applications/#{id}/offers", normalize_params(options)
+      _kw_args, params = normalize_options(options)
+      get_from_harvest_api "/applications/#{id}/offers", params
     end
 
     def current_offer_for_application(id, options = {})
@@ -82,35 +86,43 @@ module GreenhouseIo
     end
 
     def scorecards(id, options = {})
-      get_from_harvest_api "/applications/#{id}/scorecards", normalize_params(options)
+      _kw_args, params = normalize_options(options)
+      get_from_harvest_api "/applications/#{id}/scorecards", params
     end
 
     def all_scorecards(id = nil, options = {})
-      get_from_harvest_api "/scorecards/#{id}", normalize_params(options)
+      _kw_args, params = normalize_options(options)
+      get_from_harvest_api "/scorecards/#{id}", params
     end
 
     def scheduled_interviews(options = {})
-      get_resource GreenhouseIo::ScheduledInterviewCollection, normalize_params(options)
+      kw_args, params = normalize_options(options)
+      get_resource GreenhouseIo::ScheduledInterviewCollection, params, **kw_args
     end
 
     def jobs(options = {})
-      get_resource GreenhouseIo::JobCollection, normalize_params(options)
+      kw_args, params = normalize_options(options)
+      get_resource GreenhouseIo::JobCollection, params, **kw_args
     end
 
     def stages(id, options = {})
-      get_from_harvest_api "/jobs/#{id}/stages", normalize_params(options)
+      _kw_args, params = normalize_options(options)
+      get_from_harvest_api "/jobs/#{id}/stages", params
     end
 
     def job_stages(options = {})
-      get_resource GreenhouseIo::JobStageCollection, normalize_params(options)
+      kw_args, params = normalize_options(options)
+      get_resource GreenhouseIo::JobStageCollection, params, **kw_args
     end
 
     def job_post(id, options = {})
-      get_from_harvest_api "/jobs/#{id}/job_post", normalize_params(options)
+      _kw_args, params = normalize_options(options)
+      get_from_harvest_api "/jobs/#{id}/job_post", params
     end
 
     def users(options = {})
-      get_resource GreenhouseIo::UserCollection, normalize_params(options)
+      kw_args, params = normalize_options(options)
+      get_resource GreenhouseIo::UserCollection, params, **kw_args
     end
 
     def sources(id = nil, options = {})
@@ -170,8 +182,12 @@ module GreenhouseIo
 
     attr_accessor :using_with_retries # see #with_retries
 
-    def get_resource(resource_class, options)
-      resource_collection = resource_class.new(client: self, query_params: options)
+    def get_resource(resource_class, options, dehydrate_after_iteration: true)
+      resource_collection = resource_class.new(
+        client: self,
+        query_params: options,
+        dehydrate_after_iteration: dehydrate_after_iteration
+      )
 
       # Options hash must use symbols as keys!
       if options.has_key?(:id)
@@ -187,13 +203,17 @@ module GreenhouseIo
       self.link = headers['link'].to_s
     end
 
-    def normalize_params(params)
+    def normalize_options(options)
+      kw_arg_keys = %i[dehydrate_after_iteration]
+      kw_args, params = options.slice(*kw_arg_keys), options.except(*kw_arg_keys)
+
       params.each do |key, value|
         if value.respond_to?(:iso8601)
           params[key] = value.iso8601
         end
       end
-      params
+
+      [kw_args, params]
     end
   end
 end

--- a/lib/greenhouse_io/api/job.rb
+++ b/lib/greenhouse_io/api/job.rb
@@ -4,6 +4,6 @@ require 'greenhouse_io/api/resource'
 
 module GreenhouseIo
   class Job < Resource
-    ENDPOINT = "/jobs"
+    DEFAULT_ENDPOINT = "/jobs"
   end
 end

--- a/lib/greenhouse_io/api/job_stage.rb
+++ b/lib/greenhouse_io/api/job_stage.rb
@@ -4,6 +4,6 @@ require 'greenhouse_io/api/resource'
 
 module GreenhouseIo
   class JobStage < Resource
-    ENDPOINT = "/job_stages"
+    DEFAULT_ENDPOINT = "/job_stages"
   end
 end

--- a/lib/greenhouse_io/api/resource_collection.rb
+++ b/lib/greenhouse_io/api/resource_collection.rb
@@ -19,10 +19,20 @@ module GreenhouseIo
     attr_accessor :client, :resource_class, :dehydrate_after_iteration
 
     # @param dehydrate_after_iteration [Boolean] When true, we try to keep only `:dehydrated` around in the hydration arrays
-    def initialize(client:, query_params: {}, resource_class:, dehydrate_after_iteration: true)
+    def initialize(client:, endpoint: nil, query_params: {}, resource_class:, dehydrate_after_iteration: true)
       self.client             = client
       self.resource_class     = resource_class # e.g. GreenhouseIo::Application
-      self.lazy_paginators    = [LazyPaginator.new(resource_collection: self, query_params: query_params)]
+      endpoint ||= resource_class::DEFAULT_ENDPOINT
+      endpoint = "#{endpoint}#{client.path_id(query_params[:id])}"
+
+      self.lazy_paginators    = [
+        LazyPaginator.new(
+          resource_collection: self,
+          endpoint: endpoint,
+          query_params: query_params.except(:id),
+          dehydrate_after_iteration: dehydrate_after_iteration
+        )
+      ]
       self.hydrated_resources = []
       self.hydrated_pages     = []
       self.dehydrate_after_iteration = dehydrate_after_iteration

--- a/lib/greenhouse_io/api/resource_collection/lazy_paginator.rb
+++ b/lib/greenhouse_io/api/resource_collection/lazy_paginator.rb
@@ -12,13 +12,14 @@ module GreenhouseIo
     class LazyPaginator
       include Enumerable
 
-      attr_accessor :resource_collection, :query_params, :dehydrate_after_iteration
+      attr_accessor :resource_collection, :endpoint, :query_params, :dehydrate_after_iteration
 
       delegate :client, :resource_class, to: :resource_collection
 
       # @param dehydrate_after_iteration [Boolean] When true, we try to keep only `:dehydrated` around in the hydration arrays
-      def initialize(resource_collection:, query_params:, dehydrate_after_iteration: true)
+      def initialize(resource_collection:, endpoint:, query_params:, dehydrate_after_iteration: true)
         self.resource_collection = resource_collection
+        self.endpoint            = endpoint
         self.query_params        = query_params
         self.hydrated_resources  = []
         self.hydrated_pages      = []
@@ -72,9 +73,7 @@ module GreenhouseIo
           if next_page_url.present?
             client.get_from_harvest_api(next_page_url)
           else
-            # If the id is part of the params, bring it out and append to URL
-            ending = client.path_id(query_params[:id])
-            client.get_from_harvest_api("#{resource_class::ENDPOINT}#{ending}", query_params.except(:id))
+            client.get_from_harvest_api(endpoint, query_params)
           end
         end
 

--- a/lib/greenhouse_io/api/scheduled_interview.rb
+++ b/lib/greenhouse_io/api/scheduled_interview.rb
@@ -4,6 +4,6 @@ require 'greenhouse_io/api/resource'
 
 module GreenhouseIo
   class ScheduledInterview < Resource
-    ENDPOINT = "/scheduled_interviews"
+    DEFAULT_ENDPOINT = "/scheduled_interviews"
   end
 end

--- a/lib/greenhouse_io/api/scheduled_interview_collection.rb
+++ b/lib/greenhouse_io/api/scheduled_interview_collection.rb
@@ -6,7 +6,15 @@ require 'greenhouse_io/api/resource_collection'
 module GreenhouseIo
   class ScheduledInterviewCollection < ResourceCollection
     def initialize(*args, **kw_args)
-      kw_args.merge!(resource_class: ScheduledInterview)
+      query_params = kw_args.fetch(:query_params, {})
+      if (application_id = query_params[:application_id]).present?
+        endpoint = "/applications/#{application_id}#{ScheduledInterview::DEFAULT_ENDPOINT}"
+      end
+      kw_args.merge!(
+        endpoint:       endpoint,
+        query_params:   query_params.except(:application_id),
+        resource_class: ScheduledInterview
+      )
       super
     end
   end

--- a/lib/greenhouse_io/api/user.rb
+++ b/lib/greenhouse_io/api/user.rb
@@ -4,6 +4,6 @@ require 'greenhouse_io/api/resource'
 
 module GreenhouseIo
   class User < Resource
-    ENDPOINT = "/users"
+    DEFAULT_ENDPOINT = "/users"
   end
 end

--- a/spec/fixtures/cassettes/client/application_scheduled_interviews.yml
+++ b/spec/fixtures/cassettes/client/application_scheduled_interviews.yml
@@ -1,0 +1,56 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://harvest.greenhouse.io/v1/applications/165646508002/scheduled_interviews
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Basic <AUTH_VALUE>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 16 Aug 2023 17:03:18 GMT
+      Content-Type:
+      - application/json;charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept-Encoding
+      Status:
+      - 200 OK
+      Link:
+      - <https://harvest.greenhouse.io/v1/applications/165646508002/scheduled_interviews?id=165646508002&page=1&per_page=100>;
+        rel="last"
+      X-Ratelimit-Limit:
+      - '50'
+      X-Ratelimit-Remaining:
+      - '49'
+      X-Content-Type-Options:
+      - nosniff
+      X-Request-Id:
+      - 9e2c7a128de4f69d9152aa0f79602aff
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"id":191979079002,"application_id":165646508002,"external_event_id":"6ibe4gifqsro6emq6kqdfgjbjk","start":{"date_time":"2023-06-26T18:15:00.000Z"},"end":{"date_time":"2023-06-26T18:45:00.000Z"},"location":null,"video_conferencing_url":null,"status":"awaiting_feedback","created_at":"2023-06-23T03:03:21.008Z","updated_at":"2023-06-26T19:45:07.582Z","interview":{"id":10195989002,"name":"Behavioral
+        Phone Interview"},"organizer":{"id":4774287002,"first_name":"Eric","last_name":"Tipton","name":"Eric
+        Tipton","employee_id":null},"interviewers":[{"id":4774287002,"employee_id":null,"name":"Eric
+        Tipton","email":"eric.tipton@grayscaleapp.com","response_status":"accepted","scorecard_id":null}]}]'
+    http_version: 
+  recorded_at: Wed, 16 Aug 2023 17:03:18 GMT
+recorded_with: VCR 3.0.3

--- a/spec/greenhouse_io/api/client_spec.rb
+++ b/spec/greenhouse_io/api/client_spec.rb
@@ -211,13 +211,13 @@ describe GreenhouseIo::Client do
           let(:time) { Time.now }
           let(:method_args) { [{created_at: time, updated_at: time, last_activity: time}] }
           let(:get_resource) {double(get_resource)}
-  
+
           before(:each) do
             allow(@client).to(receive(:get_resource)).with(GreenhouseIo::CandidateCollection, {created_at: time, updated_at: time, last_activity: time})
           end
-  
+
           it 'converts times to iso8601' do
-            expect(@client).to receive(:get_resource).with(GreenhouseIo::CandidateCollection, {created_at: time.iso8601, updated_at: time.iso8601, last_activity: time.iso8601})
+            expect(@client).to receive(:get_resource).with(GreenhouseIo::CandidateCollection, {created_at: time.iso8601, updated_at: time.iso8601, last_activity: time.iso8601}, {})
             @client.candidates(*method_args)
           end
         end
@@ -438,11 +438,11 @@ describe GreenhouseIo::Client do
         let(:get_resource) {double(get_resource)}
 
         before(:each) do
-          allow(@client).to(receive(:get_resource)).with(GreenhouseIo::ApplicationCollection, {applied_at: time, rejected_at: time, last_activity_at: time})
+          allow(@client).to(receive(:get_resource)).with(GreenhouseIo::ApplicationCollection, {applied_at: time, rejected_at: time, last_activity_at: time}, {})
         end
 
         it 'converts times to iso8601' do
-          expect(@client).to receive(:get_resource).with(GreenhouseIo::ApplicationCollection, {applied_at: time.iso8601, rejected_at: time.iso8601, last_activity_at: time.iso8601})
+          expect(@client).to receive(:get_resource).with(GreenhouseIo::ApplicationCollection, {applied_at: time.iso8601, rejected_at: time.iso8601, last_activity_at: time.iso8601}, {})
           @client.applications(*method_args)
         end
       end
@@ -539,6 +539,32 @@ describe GreenhouseIo::Client do
         end
       end
 
+      context 'given an application_id' do
+        let(:fake_api_token) { ENV['GREENHOUSE_API_TOKEN'] }
+
+        before do
+          VCR.use_cassette('client/application_scheduled_interviews') do
+            @application_scheduled_interviews = @client.scheduled_interviews(
+              application_id: 165646508002,
+              dehydrate_after_iteration: false
+            )
+            @application_scheduled_interviews.count # cause lazy paginator to execute its query(s)
+          end
+        end
+
+        it "returns a response" do
+          expect(@application_scheduled_interviews).to_not be_empty
+        end
+
+        it "returns ScheduledInterview instances" do
+          expect(@application_scheduled_interviews.first).to be_an_instance_of(GreenhouseIo::ScheduledInterview)
+        end
+
+        it "returns details of the interviews" do
+          expect(@application_scheduled_interviews.first).to have_key(:start)
+        end
+      end
+
       context 'passes timestamp parameters' do
         let(:time) { Time.now }
         let(:method_args) { [{updated_after: time}] }
@@ -546,11 +572,11 @@ describe GreenhouseIo::Client do
         subject(:interviews) { @client.scheduled_interviews(*method_args) }
 
         before(:each) do
-          allow(@client).to(receive(:get_resource)).with(GreenhouseIo::ScheduledInterviewCollection, {updated_after: time})
+          allow(@client).to(receive(:get_resource)).with(GreenhouseIo::ScheduledInterviewCollection, {updated_after: time}, {})
         end
 
         it 'returns a response' do
-          expect(@client).to receive(:get_resource).with(GreenhouseIo::ScheduledInterviewCollection, {updated_after: time.iso8601})
+          expect(@client).to receive(:get_resource).with(GreenhouseIo::ScheduledInterviewCollection, {updated_after: time.iso8601}, {})
           @client.scheduled_interviews(*method_args)
 
         end
@@ -634,7 +660,7 @@ describe GreenhouseIo::Client do
         end
 
         it 'converts times to iso8601' do
-          expect(@client).to receive(:get_resource).with(GreenhouseIo::JobCollection, {created_at: time.iso8601, updated_at: time.iso8601, opened_at: time.iso8601, closed_at: time.iso8601})
+          expect(@client).to receive(:get_resource).with(GreenhouseIo::JobCollection, {created_at: time.iso8601, updated_at: time.iso8601, opened_at: time.iso8601, closed_at: time.iso8601}, {})
           @client.jobs(*method_args)
         end
       end
@@ -757,7 +783,7 @@ describe GreenhouseIo::Client do
         end
 
         it 'converts times to iso8601' do
-          expect(@client).to receive(:get_resource).with(GreenhouseIo::UserCollection, {created_at: time.iso8601, updated_at: time.iso8601})
+          expect(@client).to receive(:get_resource).with(GreenhouseIo::UserCollection, {created_at: time.iso8601, updated_at: time.iso8601}, {})
           @client.users(*method_args)
         end
       end


### PR DESCRIPTION
unexpected detour today :( ... this is a query we'll need to make when we receive a webhook that could trigger an automation (we'll want to persist the latest for any interviews for the application, before the automation fires)

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] Schema changes (if applicable) will play nicely with "rolling" deploy mechanism
- [ ] All UX vectors have been considered (desktop app, Chrome extension, responsive view)
- [ ] The code changed/added does not introduce security vulnerabilities

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] At least one other engineer confirms that schema changes (if applicable) will play nicely with "rolling" deploy mechanism
- [ ] At least one other engineer confirms that all UX vectors have been considered (desktop app, Chrome extension, responsive view)
- [ ] At least one other engineer has confirmed that the code changed/added will not introduce security vulnerabilities
- [ ] Issue from task tracker has a link to this pull request
