### PR TITLE
Page object: /s/next_page_url/url

### DIFF
--- a/lib/greenhouse_io/api/resource_collection/page.rb
+++ b/lib/greenhouse_io/api/resource_collection/page.rb
@@ -3,10 +3,10 @@ module GreenhouseIo
     class Page
       include Enumerable
 
-      attr_reader :next_page_url, :contents
+      attr_reader :url, :contents
 
-      def initialize(contents, next_page_url: nil, dehydrate_after_iteration: true)
-        @next_page_url = next_page_url
+      def initialize(contents, url: nil, dehydrate_after_iteration: true)
+        @url = url
         @contents = contents
         @dehydrate_after_iteration = dehydrate_after_iteration
       end

--- a/spec/greenhouse_io/api/candidate_collection_spec.rb
+++ b/spec/greenhouse_io/api/candidate_collection_spec.rb
@@ -14,11 +14,11 @@ RSpec.describe GreenhouseIo::CandidateCollection do
     last   = pages.last
 
     aggregate_failures do
-      expect(first.next_page_url).to match(/page=2&per_page=100/)
+      expect(first.url).to be_nil
       expect(first.length).to eq(100)
       expect(first.first).to be_instance_of(GreenhouseIo::Candidate)
 
-      expect(last.next_page_url).to be_nil
+      expect(last.url).to match(/page=3&per_page=100/)
       expect(last.length).to eq(18)
     end
   end


### PR DESCRIPTION
- This way, callers can cache the url value for later re-use in case processing errors occur on a particular page

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] Schema changes (if applicable) will play nicely with "rolling" deploy mechanism
- [ ] All UX vectors have been considered (desktop app, Chrome extension, responsive view)
- [ ] The code changed/added does not introduce security vulnerabilities

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] At least one other engineer confirms that schema changes (if applicable) will play nicely with "rolling" deploy mechanism
- [ ] At least one other engineer confirms that all UX vectors have been considered (desktop app, Chrome extension, responsive view)
- [ ] At least one other engineer has confirmed that the code changed/added will not introduce security vulnerabilities
- [ ] Issue from task tracker has a link to this pull request
