### PR TITLE
ability to provide /jobs/[id]/stages endpoint to LazyPaginators

### DIFF
--- a/lib/greenhouse_io/api/job_stage_collection.rb
+++ b/lib/greenhouse_io/api/job_stage_collection.rb
@@ -6,7 +6,15 @@ require 'greenhouse_io/api/resource_collection'
 module GreenhouseIo
   class JobStageCollection < ResourceCollection
     def initialize(*args, **kw_args)
-      kw_args.merge!(resource_class: JobStage)
+      query_params = kw_args.fetch(:query_params, {})
+      if (job_id = query_params[:job_id]).present?
+        endpoint = "/jobs/#{job_id}/stages"
+      end
+      kw_args.merge!(
+        endpoint:       endpoint,
+        query_params:   query_params.except(:job_id),
+        resource_class: JobStage
+      )
       super
     end
   end

--- a/spec/fixtures/cassettes/client/job_job_stages.yml
+++ b/spec/fixtures/cassettes/client/job_job_stages.yml
@@ -1,0 +1,63 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://harvest.greenhouse.io/v1/jobs/4576745002/stages
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Basic <AUTH_VALUE>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sun, 10 Sep 2023 16:28:05 GMT
+      Content-Type:
+      - application/json;charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept-Encoding
+      Link:
+      - <https://harvest.greenhouse.io/v1/jobs/4576745002/stages?id=4576745002&page=1&per_page=100>;
+        rel="last"
+      X-Ratelimit-Limit:
+      - '50'
+      X-Ratelimit-Remaining:
+      - '48'
+      X-Content-Type-Options:
+      - nosniff
+      X-Request-Id:
+      - 48ff28d30b0db12b81f8f014e0b094ce
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"id":8404059002,"name":"Application Review","created_at":"2020-06-10T16:46:28.863Z","updated_at":"2020-06-10T16:46:28.863Z","active":true,"job_id":4576745002,"priority":0,"interviews":[{"id":10195987002,"name":"Application
+        Review","schedulable":false,"interview_kit":{"id":10195993002,"content":null,"questions":[]},"estimated_minutes":1,"default_interviewer_users":[]}]},{"id":8404060002,"name":"Preliminary
+        Phone Screen","created_at":"2020-06-10T16:46:28.863Z","updated_at":"2020-06-10T16:46:28.863Z","active":true,"job_id":4576745002,"priority":1,"interviews":[{"id":10195988002,"name":"Preliminary
+        Screening Call","schedulable":true,"interview_kit":{"id":10195994002,"content":null,"questions":[]},"estimated_minutes":20,"default_interviewer_users":[]}]},{"id":8404061002,"name":"Phone
+        Interview","created_at":"2020-06-10T16:46:28.863Z","updated_at":"2020-06-10T16:46:28.863Z","active":true,"job_id":4576745002,"priority":2,"interviews":[{"id":10195989002,"name":"Behavioral
+        Phone Interview","schedulable":true,"interview_kit":{"id":10195995002,"content":null,"questions":[]},"estimated_minutes":30,"default_interviewer_users":[]}]},{"id":8404062002,"name":"Face
+        to Face","created_at":"2020-06-10T16:46:28.863Z","updated_at":"2020-06-10T16:46:28.863Z","active":true,"job_id":4576745002,"priority":3,"interviews":[{"id":10195990002,"name":"Cultural
+        Fit Interview","schedulable":true,"interview_kit":{"id":10195996002,"content":null,"questions":[]},"estimated_minutes":30,"default_interviewer_users":[]},{"id":10195991002,"name":"Peer
+        Panel Interview","schedulable":true,"interview_kit":{"id":10195997002,"content":null,"questions":[]},"estimated_minutes":30,"default_interviewer_users":[]},{"id":10195992002,"name":"Case
+        Study","schedulable":true,"interview_kit":{"id":10195998002,"content":null,"questions":[]},"estimated_minutes":45,"default_interviewer_users":[]},{"id":10195993002,"name":"Executive
+        Interview","schedulable":true,"interview_kit":{"id":10195999002,"content":null,"questions":[]},"estimated_minutes":30,"default_interviewer_users":[]}]},{"id":8404063002,"name":"Reference
+        Check","created_at":"2020-06-10T16:46:28.863Z","updated_at":"2020-06-10T16:46:28.863Z","active":true,"job_id":4576745002,"priority":4,"interviews":[{"id":10195994002,"name":"Former
+        Manager","schedulable":false,"interview_kit":{"id":10196000002,"content":null,"questions":[]},"estimated_minutes":15,"default_interviewer_users":[]}]},{"id":8404064002,"name":"Offer","created_at":"2020-06-10T16:46:28.863Z","updated_at":"2020-06-10T16:46:28.863Z","active":true,"job_id":4576745002,"priority":5,"interviews":[]}]'
+    http_version: 
+  recorded_at: Sun, 10 Sep 2023 16:28:05 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/cassettes/client/job_stages.yml
+++ b/spec/fixtures/cassettes/client/job_stages.yml
@@ -1,0 +1,49 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://harvest.greenhouse.io/v1/job_stages/8404059002
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Basic <AUTH_VALUE>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sun, 10 Sep 2023 16:29:11 GMT
+      Content-Type:
+      - application/json;charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Limit:
+      - '50'
+      X-Ratelimit-Remaining:
+      - '49'
+      X-Content-Type-Options:
+      - nosniff
+      X-Request-Id:
+      - 549e2cc3f4f29f664fcb1e8f6690bb6a
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":8404059002,"name":"Application Review","created_at":"2020-06-10T16:46:28.863Z","updated_at":"2020-06-10T16:46:28.863Z","active":true,"job_id":4576745002,"priority":0,"interviews":[{"id":10195987002,"name":"Application
+        Review","schedulable":false,"interview_kit":{"id":10195993002,"content":null,"questions":[]},"estimated_minutes":1,"default_interviewer_users":[]}]}'
+    http_version: 
+  recorded_at: Sun, 10 Sep 2023 16:29:11 GMT
+recorded_with: VCR 3.0.3

--- a/spec/greenhouse_io/api/client_spec.rb
+++ b/spec/greenhouse_io/api/client_spec.rb
@@ -701,6 +701,70 @@ describe GreenhouseIo::Client do
       end
     end
 
+    describe "#job_stages" do
+      let(:fake_api_token) { ENV['GREENHOUSE_API_TOKEN'] }
+
+      context 'given an id' do
+        before do
+          VCR.use_cassette('client/job_stages') do
+            @job_stage = @client.job_stages(id: 8404059002)
+          end
+        end
+
+        it "returns a response" do
+          expect(@job_stage).to_not be_nil
+        end
+
+        it "returns a JobStage instance" do
+          expect(@job_stage).to be_an_instance_of(GreenhouseIo::JobStage)
+        end
+
+        it "returns details of the job_stage" do
+          expect(@job_stage).to have_key(:name)
+        end
+      end
+
+      context 'given a job_id' do
+        before do
+          VCR.use_cassette('client/job_job_stages') do
+            @job_job_stages = @client.job_stages(
+              job_id: 4576745002,
+              dehydrate_after_iteration: false
+            )
+            @job_job_stages.count # cause lazy paginator to execute its query(s)
+          end
+        end
+
+        it "returns a response" do
+          expect(@job_job_stages).to_not be_empty
+        end
+
+        it "returns JobStage instances" do
+          expect(@job_job_stages.first).to be_an_instance_of(GreenhouseIo::JobStage)
+        end
+
+        it "returns details of the job stages" do
+          expect(@job_job_stages.first).to have_key(:name)
+        end
+      end
+
+      context 'passes timestamp parameters' do
+        let(:time) { Time.now }
+        let(:method_args) { [{updated_after: time}] }
+        let(:get_resource) {double(get_resource)}
+        subject(:interviews) { @client.job_stages(*method_args) }
+
+        before(:each) do
+          allow(@client).to(receive(:get_resource)).with(GreenhouseIo::JobStageCollection, {updated_after: time}, {})
+        end
+
+        it 'returns a response' do
+          expect(@client).to receive(:get_resource).with(GreenhouseIo::JobStageCollection, {updated_after: time.iso8601}, {})
+          @client.job_stages(*method_args)
+        end
+      end
+    end
+
     describe "#job_post" do
       before do
         VCR.use_cassette('client/job_post') do


### PR DESCRIPTION
## Description of the change

[DWISOTT](https://en.wikipedia.org/wiki/Does_exactly_what_it_says_on_the_tin)

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] Schema changes (if applicable) will play nicely with "rolling" deploy mechanism
- [ ] All UX vectors have been considered (desktop app, Chrome extension, responsive view)
- [ ] The code changed/added does not introduce security vulnerabilities

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] At least one other engineer confirms that schema changes (if applicable) will play nicely with "rolling" deploy mechanism
- [ ] At least one other engineer confirms that all UX vectors have been considered (desktop app, Chrome extension, responsive view)
- [ ] At least one other engineer has confirmed that the code changed/added will not introduce security vulnerabilities
- [ ] Issue from task tracker has a link to this pull request
