### PR TITLE
Fix usage of LinkHeaderParser

### DIFF
--- a/greenhouse_io.gemspec
+++ b/greenhouse_io.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency('activesupport')
   spec.add_runtime_dependency('hashie')
   spec.add_runtime_dependency('httmultiparty', '~> 0.3.16')
-  spec.add_runtime_dependency('link-header-parser')
+  spec.add_runtime_dependency('link-header-parser', '~> 7.0.1')
   spec.add_runtime_dependency('retriable')
   spec.required_ruby_version = '>= 2.6.6'
 

--- a/lib/greenhouse_io/api/resource_collection/lazy_paginator.rb
+++ b/lib/greenhouse_io/api/resource_collection/lazy_paginator.rb
@@ -79,7 +79,7 @@ module GreenhouseIo
           end
         end
 
-        links = LinkHeaderParser.parse(client.link.to_s, base: client.class.base_uri)
+        links = LinkHeaderParser.parse(client.link.to_s, base_uri: client.class.base_uri)
         self.next_page_url       = links.find { |link| link.relation_types == ['next'] }&.target_uri
         self.all_pages_requested = next_page_url.nil?
 

--- a/lib/greenhouse_io/version.rb
+++ b/lib/greenhouse_io/version.rb
@@ -1,3 +1,3 @@
 module GreenhouseIo
-  VERSION = "3.8.0-grayscale"
+  VERSION = "3.8.1-grayscale"
 end


### PR DESCRIPTION
## Description of the change

We didn't pin the version of `link-header-parser` and a recent update has broken our usage of it.

## Type of change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] Schema changes (if applicable) will play nicely with "rolling" deploy mechanism
- [ ] All UX vectors have been considered (desktop app, Chrome extension, responsive view)
- [ ] The code changed/added does not introduce security vulnerabilities

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] At least one other engineer confirms that schema changes (if applicable) will play nicely with "rolling" deploy mechanism
- [ ] At least one other engineer confirms that all UX vectors have been considered (desktop app, Chrome extension, responsive view)
- [ ] At least one other engineer has confirmed that the code changed/added will not introduce security vulnerabilities
- [ ] Issue from task tracker has a link to this pull request
