### PR TITLE
bump version to 3.8.2-grayscale

### DIFF
--- a/lib/greenhouse_io/version.rb
+++ b/lib/greenhouse_io/version.rb
@@ -1,3 +1,3 @@
 module GreenhouseIo
-  VERSION = "3.8.1-grayscale"
+  VERSION = "3.8.2-grayscale"
 end


### PR DESCRIPTION
Bumps gem version so cATs can pin to this tag and avoid transitive dependency upgrades