### PR TITLE
Add V3::PartnerClient for OAuth Authorization Code Grant flow

### DIFF
--- a/lib/greenhouse_io/error.rb
+++ b/lib/greenhouse_io/error.rb
@@ -7,4 +7,9 @@ module GreenhouseIo
       @code = code
     end
   end
+
+  # Raised when a Partner refresh token is expired or invalid (24-hour TTL
+  # passed, already used, or revoked). Signals to the consumer that the user
+  # must re-authorize through the Greenhouse OAuth consent flow.
+  class ReauthorizationRequired < Error; end
 end

--- a/lib/greenhouse_io/v3.rb
+++ b/lib/greenhouse_io/v3.rb
@@ -1,7 +1,15 @@
-require 'greenhouse_io/v3/token_manager'
-require 'greenhouse_io/v3/client'
+require 'greenhouse_io/v3/base_client'
+require 'greenhouse_io/v3/custom_token_manager'
+require 'greenhouse_io/v3/custom_client'
+require 'greenhouse_io/v3/partner_token_manager'
+require 'greenhouse_io/v3/partner_client'
 
 module GreenhouseIo
   module V3
+    # Backward-compatible aliases for the pre-rename names. Existing consumers
+    # can keep using V3::Client / V3::TokenManager and migrate to the explicit
+    # Custom* names at their own pace.
+    Client = CustomClient
+    TokenManager = CustomTokenManager
   end
 end

--- a/lib/greenhouse_io/v3.rb
+++ b/lib/greenhouse_io/v3.rb
@@ -1,4 +1,5 @@
 require 'greenhouse_io/v3/base_client'
+require 'greenhouse_io/v3/base_token_manager'
 require 'greenhouse_io/v3/custom_token_manager'
 require 'greenhouse_io/v3/custom_client'
 require 'greenhouse_io/v3/partner_token_manager'

--- a/lib/greenhouse_io/v3/base_client.rb
+++ b/lib/greenhouse_io/v3/base_client.rb
@@ -12,7 +12,10 @@ require 'retriable'
 
 module GreenhouseIo
   module V3
-    class Client
+    # Shared HTTP/API behavior for V3 clients. Subclasses must set
+    # @token_manager in their #initialize (calling super to set up the
+    # shared request state).
+    class BaseClient
       include HTTMultiParty
       include GreenhouseIo::API
 
@@ -22,13 +25,7 @@ module GreenhouseIo
 
       base_uri 'https://harvest.greenhouse.io/v3'
 
-      def initialize(client_id:, client_secret:, sub:, token_store: {})
-        @token_manager = TokenManager.new(
-          client_id: client_id,
-          client_secret: client_secret,
-          sub: sub,
-          token_store: token_store
-        )
+      def initialize
         @token_refreshed_this_request = false
         self.using_with_retries = false
       end

--- a/lib/greenhouse_io/v3/base_token_manager.rb
+++ b/lib/greenhouse_io/v3/base_token_manager.rb
@@ -1,0 +1,53 @@
+require 'httparty'
+require 'json'
+require 'base64'
+require 'time'
+
+module GreenhouseIo
+  module V3
+    # Shared token-request/credential behavior for V3 token managers.
+    # Subclasses set @client_id, @client_secret, and @token_store, and
+    # implement the grant-specific #refresh! / #force_refresh! flows.
+    class BaseTokenManager
+      AUTH_BASE_URI = "https://auth.greenhouse.io".freeze
+
+      # Seconds of remaining lifetime below which a cached token is treated
+      # as expired, so it is refreshed before it can lapse mid-request.
+      REFRESH_BUFFER = 30
+
+      attr_reader :client_id, :client_secret, :token_store
+
+      private
+
+      def token_valid?
+        token_store[:access_token] &&
+          token_store[:expires_at] &&
+          Time.parse(token_store[:expires_at]) > Time.now + REFRESH_BUFFER
+      end
+
+      def post_token_request(params)
+        response = HTTParty.post(
+          "#{AUTH_BASE_URI}/token",
+          body: params,
+          headers: { "Authorization" => "Basic #{encoded_credentials}" }
+        )
+
+        unless response.success?
+          raise GreenhouseIo::Error.new(response.body, response.code)
+        end
+
+        JSON.parse(response.body)
+      end
+
+      def store_token_response(response)
+        token_store[:access_token] = response["access_token"]
+        token_store[:refresh_token] = response["refresh_token"]
+        token_store[:expires_at] = response["expires_at"]
+      end
+
+      def encoded_credentials
+        Base64.strict_encode64("#{client_id}:#{client_secret}")
+      end
+    end
+  end
+end

--- a/lib/greenhouse_io/v3/custom_client.rb
+++ b/lib/greenhouse_io/v3/custom_client.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'greenhouse_io/v3/base_client'
+require 'greenhouse_io/v3/custom_token_manager'
+
+module GreenhouseIo
+  module V3
+    # Client for Greenhouse Custom Integrations. Authenticates via the
+    # client_credentials grant (on behalf of `sub`), with refresh-token
+    # fallback handled by CustomTokenManager.
+    class CustomClient < BaseClient
+      def initialize(client_id:, client_secret:, sub:, token_store: {})
+        super()
+        @token_manager = CustomTokenManager.new(
+          client_id: client_id,
+          client_secret: client_secret,
+          sub: sub,
+          token_store: token_store
+        )
+      end
+    end
+  end
+end

--- a/lib/greenhouse_io/v3/custom_token_manager.rb
+++ b/lib/greenhouse_io/v3/custom_token_manager.rb
@@ -1,14 +1,12 @@
-require 'httparty'
-require 'json'
-require 'base64'
-require 'time'
+require 'greenhouse_io/v3/base_token_manager'
 
 module GreenhouseIo
   module V3
-    class CustomTokenManager
-      AUTH_BASE_URI = "https://auth.greenhouse.io".freeze
-
-      attr_reader :client_id, :client_secret, :sub, :token_store
+    # Token manager for Custom Integrations. Uses the client_credentials
+    # grant (on behalf of `sub`), falling back to a fresh fetch when a
+    # refresh fails.
+    class CustomTokenManager < BaseTokenManager
+      attr_reader :sub
 
       def initialize(client_id:, client_secret:, sub:, token_store: {})
         @client_id = client_id
@@ -39,12 +37,6 @@ module GreenhouseIo
 
       private
 
-      def token_valid?
-        token_store[:access_token] &&
-          token_store[:expires_at] &&
-          Time.parse(token_store[:expires_at]) > Time.now + 30
-      end
-
       def fetch!
         response = post_token_request("grant_type" => "client_credentials", "sub" => sub)
         store_token_response(response)
@@ -58,30 +50,6 @@ module GreenhouseIo
         store_token_response(response)
       rescue GreenhouseIo::Error
         fetch!
-      end
-
-      def post_token_request(params)
-        response = HTTParty.post(
-          "#{AUTH_BASE_URI}/token",
-          body: params,
-          headers: { "Authorization" => "Basic #{encoded_credentials}" }
-        )
-
-        unless response.success?
-          raise GreenhouseIo::Error.new(response.body, response.code)
-        end
-
-        JSON.parse(response.body)
-      end
-
-      def store_token_response(response)
-        token_store[:access_token] = response["access_token"]
-        token_store[:refresh_token] = response["refresh_token"]
-        token_store[:expires_at] = response["expires_at"]
-      end
-
-      def encoded_credentials
-        Base64.strict_encode64("#{client_id}:#{client_secret}")
       end
     end
   end

--- a/lib/greenhouse_io/v3/custom_token_manager.rb
+++ b/lib/greenhouse_io/v3/custom_token_manager.rb
@@ -1,0 +1,88 @@
+require 'httparty'
+require 'json'
+require 'base64'
+require 'time'
+
+module GreenhouseIo
+  module V3
+    class CustomTokenManager
+      AUTH_BASE_URI = "https://auth.greenhouse.io".freeze
+
+      attr_reader :client_id, :client_secret, :sub, :token_store
+
+      def initialize(client_id:, client_secret:, sub:, token_store: {})
+        @client_id = client_id
+        @client_secret = client_secret
+        @sub = sub
+        @token_store = token_store
+      end
+
+      def access_token
+        return token_store[:access_token] if token_valid?
+
+        if token_store[:refresh_token]
+          refresh!
+        else
+          fetch!
+        end
+
+        token_store[:access_token]
+      end
+
+      def force_refresh!
+        if token_store[:refresh_token]
+          refresh!
+        else
+          fetch!
+        end
+      end
+
+      private
+
+      def token_valid?
+        token_store[:access_token] &&
+          token_store[:expires_at] &&
+          Time.parse(token_store[:expires_at]) > Time.now + 30
+      end
+
+      def fetch!
+        response = post_token_request("grant_type" => "client_credentials", "sub" => sub)
+        store_token_response(response)
+      end
+
+      def refresh!
+        response = post_token_request(
+          "grant_type" => "refresh_token",
+          "refresh_token" => token_store[:refresh_token]
+        )
+        store_token_response(response)
+      rescue GreenhouseIo::Error
+        fetch!
+      end
+
+      def post_token_request(params)
+        response = HTTParty.post(
+          "#{AUTH_BASE_URI}/token",
+          body: params,
+          headers: { "Authorization" => "Basic #{encoded_credentials}" }
+        )
+
+        unless response.success?
+          raise GreenhouseIo::Error.new(response.body, response.code)
+        end
+
+        JSON.parse(response.body)
+      end
+
+      def store_token_response(response)
+        token_store[:access_token] = response["access_token"]
+        token_store[:refresh_token] = response["refresh_token"]
+        token_store[:expires_at] = response["expires_at"]
+      end
+
+      def encoded_credentials
+        Base64.strict_encode64("#{client_id}:#{client_secret}")
+      end
+    end
+  end
+end

--- a/lib/greenhouse_io/v3/partner_client.rb
+++ b/lib/greenhouse_io/v3/partner_client.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'greenhouse_io/v3/base_client'
+require 'greenhouse_io/v3/partner_token_manager'
+
+module GreenhouseIo
+  module V3
+    # Client for Greenhouse Partner Integrations. Authenticates via the
+    # OAuth 2.0 Authorization Code Grant, with refresh handled by
+    # PartnerTokenManager. There is no `sub`, and token_store is required
+    # since Partner clients always need persisted tokens.
+    class PartnerClient < BaseClient
+      def initialize(client_id:, client_secret:, token_store:)
+        super()
+        @token_manager = PartnerTokenManager.new(
+          client_id: client_id,
+          client_secret: client_secret,
+          token_store: token_store
+        )
+      end
+    end
+  end
+end

--- a/lib/greenhouse_io/v3/partner_token_manager.rb
+++ b/lib/greenhouse_io/v3/partner_token_manager.rb
@@ -1,7 +1,4 @@
-require 'httparty'
-require 'json'
-require 'base64'
-require 'time'
+require 'greenhouse_io/v3/base_token_manager'
 
 module GreenhouseIo
   module V3
@@ -13,11 +10,7 @@ module GreenhouseIo
     # refresh, so the new one must be persisted. When refresh fails, the
     # failure is terminal until the user re-authorizes through Greenhouse, so
     # a ReauthorizationRequired error is raised.
-    class PartnerTokenManager
-      AUTH_BASE_URI = "https://auth.greenhouse.io".freeze
-
-      attr_reader :client_id, :client_secret, :token_store
-
+    class PartnerTokenManager < BaseTokenManager
       def initialize(client_id:, client_secret:, token_store:)
         @client_id = client_id
         @client_secret = client_secret
@@ -35,13 +28,18 @@ module GreenhouseIo
 
       private
 
-      def token_valid?
-        token_store[:access_token] &&
-          token_store[:expires_at] &&
-          Time.parse(token_store[:expires_at]) > Time.now + 30
+      def refresh!
+        # No refresh token means the user was never authorized (or it was
+        # revoked/wiped) -- a terminal state. Fail fast without a doomed
+        # network call.
+        if token_store[:refresh_token].to_s.empty?
+          raise GreenhouseIo::ReauthorizationRequired.new("No refresh token available")
+        end
+
+        request_refresh!
       end
 
-      def refresh!
+      def request_refresh!
         response = post_token_request(
           "grant_type" => "refresh_token",
           "refresh_token" => token_store[:refresh_token]
@@ -49,30 +47,6 @@ module GreenhouseIo
         store_token_response(response)
       rescue GreenhouseIo::Error => e
         raise GreenhouseIo::ReauthorizationRequired.new(e.message, e.code)
-      end
-
-      def post_token_request(params)
-        response = HTTParty.post(
-          "#{AUTH_BASE_URI}/token",
-          body: params,
-          headers: { "Authorization" => "Basic #{encoded_credentials}" }
-        )
-
-        unless response.success?
-          raise GreenhouseIo::Error.new(response.body, response.code)
-        end
-
-        JSON.parse(response.body)
-      end
-
-      def store_token_response(response)
-        token_store[:access_token] = response["access_token"]
-        token_store[:refresh_token] = response["refresh_token"]
-        token_store[:expires_at] = response["expires_at"]
-      end
-
-      def encoded_credentials
-        Base64.strict_encode64("#{client_id}:#{client_secret}")
       end
     end
   end

--- a/lib/greenhouse_io/v3/partner_token_manager.rb
+++ b/lib/greenhouse_io/v3/partner_token_manager.rb
@@ -36,7 +36,17 @@ module GreenhouseIo
           raise GreenhouseIo::ReauthorizationRequired.new("No refresh token available")
         end
 
-        request_refresh!
+        if token_store.respond_to?(:with_refresh_lock)
+          token_store.with_refresh_lock do
+            token_store.reload if token_store.respond_to?(:reload)
+            # Another process may have refreshed while we waited for the lock.
+            return if token_valid?
+
+            request_refresh!
+          end
+        else
+          request_refresh!
+        end
       end
 
       def request_refresh!

--- a/lib/greenhouse_io/v3/partner_token_manager.rb
+++ b/lib/greenhouse_io/v3/partner_token_manager.rb
@@ -5,36 +5,32 @@ require 'time'
 
 module GreenhouseIo
   module V3
-    class TokenManager
+    # Handles the OAuth 2.0 Authorization Code Grant token lifecycle
+    # (post-authorization) for Partner integrations.
+    #
+    # Unlike CustomTokenManager, this cannot self-heal: there is no
+    # client_credentials fetch fallback. The refresh token rotates on every
+    # refresh, so the new one must be persisted. When refresh fails, the
+    # failure is terminal until the user re-authorizes through Greenhouse, so
+    # a ReauthorizationRequired error is raised.
+    class PartnerTokenManager
       AUTH_BASE_URI = "https://auth.greenhouse.io".freeze
 
-      attr_reader :client_id, :client_secret, :sub, :token_store
+      attr_reader :client_id, :client_secret, :token_store
 
-      def initialize(client_id:, client_secret:, sub:, token_store: {})
+      def initialize(client_id:, client_secret:, token_store:)
         @client_id = client_id
         @client_secret = client_secret
-        @sub = sub
         @token_store = token_store
       end
 
       def access_token
-        return token_store[:access_token] if token_valid?
-
-        if token_store[:refresh_token]
-          refresh!
-        else
-          fetch!
-        end
-
+        refresh! unless token_valid?
         token_store[:access_token]
       end
 
       def force_refresh!
-        if token_store[:refresh_token]
-          refresh!
-        else
-          fetch!
-        end
+        refresh!
       end
 
       private
@@ -45,19 +41,14 @@ module GreenhouseIo
           Time.parse(token_store[:expires_at]) > Time.now + 30
       end
 
-      def fetch!
-        response = post_token_request("grant_type" => "client_credentials", "sub" => sub)
-        store_token_response(response)
-      end
-
       def refresh!
         response = post_token_request(
           "grant_type" => "refresh_token",
           "refresh_token" => token_store[:refresh_token]
         )
         store_token_response(response)
-      rescue GreenhouseIo::Error
-        fetch!
+      rescue GreenhouseIo::Error => e
+        raise GreenhouseIo::ReauthorizationRequired.new(e.message, e.code)
       end
 
       def post_token_request(params)

--- a/lib/greenhouse_io/v3/partner_token_manager.rb
+++ b/lib/greenhouse_io/v3/partner_token_manager.rb
@@ -37,10 +37,16 @@ module GreenhouseIo
         end
 
         if token_store.respond_to?(:with_refresh_lock)
+          # Snapshot the token we are superseding BEFORE waiting for the lock.
+          token_before = token_store[:access_token]
           token_store.with_refresh_lock do
             token_store.reload if token_store.respond_to?(:reload)
-            # Another process may have refreshed while we waited for the lock.
-            return if token_valid?
+            # Skip only if another process already replaced the token while we
+            # waited for the lock (stored access token changed AND is valid).
+            # We must NOT skip merely because token_valid? is true: a
+            # 401-driven force_refresh! arrives with an unexpired-but-rejected
+            # token and must actually refresh.
+            return if token_store[:access_token] != token_before && token_valid?
 
             request_refresh!
           end

--- a/lib/greenhouse_io/version.rb
+++ b/lib/greenhouse_io/version.rb
@@ -1,3 +1,3 @@
 module GreenhouseIo
-  VERSION = "3.8.2-grayscale"
+  VERSION = "3.8.3-grayscale"
 end

--- a/spec/greenhouse_io/v3/aliases_spec.rb
+++ b/spec/greenhouse_io/v3/aliases_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# These aliases preserve the pre-rename names for existing consumers. The
+# assertions guard against a future rename of the Custom* classes silently
+# orphaning the alias and breaking consumers still calling V3::Client /
+# V3::TokenManager.
+RSpec.describe "GreenhouseIo::V3 backward-compatible aliases" do
+  it "aliases V3::Client to V3::CustomClient" do
+    expect(GreenhouseIo::V3::Client).to equal(GreenhouseIo::V3::CustomClient)
+  end
+
+  it "aliases V3::TokenManager to V3::CustomTokenManager" do
+    expect(GreenhouseIo::V3::TokenManager).to equal(GreenhouseIo::V3::CustomTokenManager)
+  end
+end

--- a/spec/greenhouse_io/v3/custom_client_spec.rb
+++ b/spec/greenhouse_io/v3/custom_client_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe GreenhouseIo::V3::Client do
+RSpec.describe GreenhouseIo::V3::CustomClient do
   let(:token_store) do
     {
       access_token: "test_bearer_token",

--- a/spec/greenhouse_io/v3/custom_token_manager_spec.rb
+++ b/spec/greenhouse_io/v3/custom_token_manager_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe GreenhouseIo::V3::TokenManager do
+RSpec.describe GreenhouseIo::V3::CustomTokenManager do
   let(:token_store) { {} }
   let(:manager) do
     described_class.new(

--- a/spec/greenhouse_io/v3/partner_client_spec.rb
+++ b/spec/greenhouse_io/v3/partner_client_spec.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe GreenhouseIo::V3::PartnerClient do
+  let(:token_store) do
+    {
+      access_token: "test_bearer_token",
+      expires_at: (Time.now + 3600).iso8601
+    }
+  end
+
+  let(:client) do
+    described_class.new(
+      client_id: "test_client_id",
+      client_secret: "test_client_secret",
+      token_store: token_store
+    )
+  end
+
+  let(:jobs_response_body) do
+    [{ "id" => 1, "name" => "Software Engineer" }, { "id" => 2, "name" => "Designer" }]
+  end
+
+  let(:default_response_headers) do
+    {
+      "Content-Type" => "application/json",
+      "x-ratelimit-limit" => "50",
+      "x-ratelimit-remaining" => "49",
+      "link" => ""
+    }
+  end
+
+  before do
+    stub_request(:get, /harvest\.greenhouse\.io\/v3/)
+      .with(headers: { "Authorization" => "Bearer test_bearer_token" })
+      .to_return(
+        status: 200,
+        body: JSON.dump(jobs_response_body),
+        headers: default_response_headers
+      )
+  end
+
+  describe "#initialize" do
+    it "does not require a sub argument" do
+      expect(described_class.instance_method(:initialize).parameters).not_to include([:keyreq, :sub])
+    end
+  end
+
+  describe "#jobs" do
+    it "delegates to BaseClient and returns a JobCollection" do
+      result = client.jobs
+      expect(result).to be_a(GreenhouseIo::JobCollection)
+    end
+  end
+
+  describe "#get_from_harvest_api" do
+    context "successful request" do
+      it "makes a GET with Bearer auth" do
+        result = client.get_from_harvest_api("/jobs", { per_page: 2 })
+        expect(result).to be_an(Array)
+        expect(result.first["id"]).to eq(1)
+      end
+    end
+
+    context "when token is expired (401)" do
+      let(:token_response) do
+        {
+          "access_token" => "refreshed_token",
+          "refresh_token" => "rotated_refresh",
+          "expires_at" => (Time.now + 3600).iso8601
+        }
+      end
+
+      before do
+        token_store[:refresh_token] = "stored_refresh_token"
+
+        stub_request(:get, /harvest\.greenhouse\.io\/v3/)
+          .with(headers: { "Authorization" => "Bearer expired_token" })
+          .to_return(status: 401, body: '{"message":"Unauthorized"}', headers: default_response_headers)
+
+        stub_request(:post, "https://auth.greenhouse.io/token")
+          .to_return(status: 200, body: JSON.dump(token_response), headers: { "Content-Type" => "application/json" })
+
+        stub_request(:get, /harvest\.greenhouse\.io\/v3/)
+          .with(headers: { "Authorization" => "Bearer refreshed_token" })
+          .to_return(status: 200, body: JSON.dump(jobs_response_body), headers: default_response_headers)
+      end
+
+      it "refreshes and retries" do
+        token_store[:access_token] = "expired_token"
+        token_store[:expires_at] = (Time.now + 3600).iso8601
+
+        result = client.get_from_harvest_api("/jobs", { per_page: 2 })
+        expect(result).to be_an(Array)
+        expect(token_store[:access_token]).to eq("refreshed_token")
+      end
+    end
+
+    context "when token is expired (401) and refresh fails" do
+      before do
+        token_store[:access_token] = "expired_token"
+        token_store[:expires_at] = (Time.now + 3600).iso8601
+        token_store[:refresh_token] = "bad_refresh_token"
+
+        stub_request(:get, /harvest\.greenhouse\.io\/v3/)
+          .with(headers: { "Authorization" => "Bearer expired_token" })
+          .to_return(status: 401, body: '{"message":"Unauthorized"}', headers: default_response_headers)
+
+        stub_request(:post, "https://auth.greenhouse.io/token")
+          .to_return(status: 400, body: '{"error":"invalid_grant"}')
+      end
+
+      it "raises ReauthorizationRequired" do
+        expect do
+          client.get_from_harvest_api("/jobs", { per_page: 2 })
+        end.to raise_error(GreenhouseIo::ReauthorizationRequired)
+      end
+    end
+  end
+end

--- a/spec/greenhouse_io/v3/partner_token_manager_spec.rb
+++ b/spec/greenhouse_io/v3/partner_token_manager_spec.rb
@@ -47,6 +47,19 @@ RSpec.describe GreenhouseIo::V3::PartnerTokenManager do
       end
     end
 
+    context "when no refresh token is present" do
+      before do
+        token_store[:access_token] = "expired_token"
+        token_store[:expires_at] = (Time.now - 60).iso8601
+        # no refresh_token
+      end
+
+      it "raises ReauthorizationRequired without making a request" do
+        expect(HTTParty).not_to receive(:post)
+        expect { manager.access_token }.to raise_error(GreenhouseIo::ReauthorizationRequired)
+      end
+    end
+
     context "when refresh fails" do
       before do
         token_store[:access_token] = "expired_token"

--- a/spec/greenhouse_io/v3/partner_token_manager_spec.rb
+++ b/spec/greenhouse_io/v3/partner_token_manager_spec.rb
@@ -113,4 +113,73 @@ RSpec.describe GreenhouseIo::V3::PartnerTokenManager do
       end
     end
   end
+
+  describe "#access_token with a locking store" do
+    let(:locking_store) do
+      Class.new do
+        attr_reader :lock_calls, :reload_calls, :data
+        def initialize(data)
+          @data = data
+          @lock_calls = 0
+          @reload_calls = 0
+        end
+        def [](k)
+          @data[k]
+        end
+        def []=(k, v)
+          @data[k] = v
+        end
+        def with_refresh_lock
+          @lock_calls += 1
+          yield
+        end
+        def reload
+          @reload_calls += 1
+        end
+      end.new(store_data)
+    end
+
+    let(:manager) do
+      described_class.new(
+        client_id: "test_client_id",
+        client_secret: "test_client_secret",
+        token_store: locking_store
+      )
+    end
+
+    context "when token is expired" do
+      let(:store_data) do
+        { refresh_token: "stored_refresh_token", access_token: "old", expires_at: (Time.now - 60).iso8601 }
+      end
+
+      before do
+        stub_request(:post, "https://auth.greenhouse.io/token")
+          .with(body: { "grant_type" => "refresh_token", "refresh_token" => "stored_refresh_token" })
+          .to_return(
+            status: 200,
+            body: { access_token: "refreshed_token", refresh_token: "rotated", expires_at: (Time.now + 3600).iso8601 }.to_json,
+            headers: { "Content-Type" => "application/json" }
+          )
+      end
+
+      it "refreshes inside the lock and reloads first" do
+        expect(manager.access_token).to eq("refreshed_token")
+        expect(locking_store.lock_calls).to eq(1)
+        expect(locking_store.reload_calls).to eq(1)
+      end
+    end
+
+    context "when another process already refreshed (valid after reload)" do
+      let(:store_data) do
+        { refresh_token: "stored_refresh_token", access_token: "fresh", expires_at: (Time.now + 3600).iso8601 }
+      end
+
+      it "acquires the lock, reloads, and skips the HTTP refresh" do
+        manager.send(:refresh!)
+        expect(locking_store.lock_calls).to eq(1)
+        expect(locking_store.reload_calls).to eq(1)
+        expect(WebMock).not_to have_requested(:post, "https://auth.greenhouse.io/token")
+      end
+    end
+  end
 end

--- a/spec/greenhouse_io/v3/partner_token_manager_spec.rb
+++ b/spec/greenhouse_io/v3/partner_token_manager_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe GreenhouseIo::V3::PartnerTokenManager do
+  let(:token_store) { {} }
+  let(:manager) do
+    described_class.new(
+      client_id: "test_client_id",
+      client_secret: "test_client_secret",
+      token_store: token_store
+    )
+  end
+
+  describe "#access_token" do
+    context "when token_store has a valid token" do
+      before do
+        token_store[:access_token] = "cached_token"
+        token_store[:expires_at] = (Time.now + 3600).iso8601
+      end
+
+      it "returns the cached token without making a request" do
+        expect(HTTParty).not_to receive(:post)
+        expect(manager.access_token).to eq("cached_token")
+      end
+    end
+
+    context "when token is expired and refresh_token exists" do
+      before do
+        token_store[:access_token] = "expired_token"
+        token_store[:expires_at] = (Time.now - 60).iso8601
+        token_store[:refresh_token] = "stored_refresh_token"
+
+        stub_request(:post, "https://auth.greenhouse.io/token")
+          .with(body: { "grant_type" => "refresh_token", "refresh_token" => "stored_refresh_token" })
+          .to_return(
+            status: 200,
+            body: { access_token: "refreshed_token", refresh_token: "rotated_refresh", expires_at: (Time.now + 3600).iso8601 }.to_json,
+            headers: { "Content-Type" => "application/json" }
+          )
+      end
+
+      it "refreshes the token and stores the rotated refresh token" do
+        expect(manager.access_token).to eq("refreshed_token")
+        expect(token_store[:access_token]).to eq("refreshed_token")
+        expect(token_store[:refresh_token]).to eq("rotated_refresh")
+      end
+    end
+
+    context "when refresh fails" do
+      before do
+        token_store[:access_token] = "expired_token"
+        token_store[:expires_at] = (Time.now - 60).iso8601
+        token_store[:refresh_token] = "bad_refresh_token"
+
+        stub_request(:post, "https://auth.greenhouse.io/token")
+          .with(body: { "grant_type" => "refresh_token", "refresh_token" => "bad_refresh_token" })
+          .to_return(status: 400, body: '{"error":"invalid_grant"}')
+      end
+
+      it "raises ReauthorizationRequired" do
+        expect { manager.access_token }.to raise_error(GreenhouseIo::ReauthorizationRequired)
+      end
+    end
+  end
+
+  describe "#force_refresh!" do
+    context "on success" do
+      before do
+        token_store[:access_token] = "old_token"
+        token_store[:expires_at] = (Time.now + 3600).iso8601
+        token_store[:refresh_token] = "stored_refresh_token"
+
+        stub_request(:post, "https://auth.greenhouse.io/token")
+          .with(body: { "grant_type" => "refresh_token", "refresh_token" => "stored_refresh_token" })
+          .to_return(
+            status: 200,
+            body: { access_token: "force_refreshed", refresh_token: "rotated_refresh", expires_at: (Time.now + 3600).iso8601 }.to_json,
+            headers: { "Content-Type" => "application/json" }
+          )
+      end
+
+      it "refreshes even when token is still valid" do
+        manager.force_refresh!
+        expect(token_store[:access_token]).to eq("force_refreshed")
+      end
+    end
+
+    context "on failure" do
+      before do
+        token_store[:refresh_token] = "bad_refresh_token"
+
+        stub_request(:post, "https://auth.greenhouse.io/token")
+          .with(body: { "grant_type" => "refresh_token", "refresh_token" => "bad_refresh_token" })
+          .to_return(status: 400, body: '{"error":"invalid_grant"}')
+      end
+
+      it "raises ReauthorizationRequired" do
+        expect { manager.force_refresh! }.to raise_error(GreenhouseIo::ReauthorizationRequired)
+      end
+    end
+  end
+end

--- a/spec/greenhouse_io/v3/partner_token_manager_spec.rb
+++ b/spec/greenhouse_io/v3/partner_token_manager_spec.rb
@@ -116,10 +116,13 @@ RSpec.describe GreenhouseIo::V3::PartnerTokenManager do
 
   describe "#access_token with a locking store" do
     let(:locking_store) do
+      # on_reload simulates another process having refreshed while we waited
+      # for the lock: it mutates @data when #reload is called.
       Class.new do
         attr_reader :lock_calls, :reload_calls, :data
-        def initialize(data)
+        def initialize(data, on_reload)
           @data = data
+          @on_reload = on_reload
           @lock_calls = 0
           @reload_calls = 0
         end
@@ -135,9 +138,12 @@ RSpec.describe GreenhouseIo::V3::PartnerTokenManager do
         end
         def reload
           @reload_calls += 1
+          @data.merge!(@on_reload) if @on_reload
         end
-      end.new(store_data)
+      end.new(store_data, on_reload)
     end
+
+    let(:on_reload) { nil }
 
     let(:manager) do
       described_class.new(
@@ -169,9 +175,14 @@ RSpec.describe GreenhouseIo::V3::PartnerTokenManager do
       end
     end
 
-    context "when another process already refreshed (valid after reload)" do
+    context "when another process refreshed the token while we waited for the lock" do
+      # We enter with a stale/expired token; reload reveals a DIFFERENT, valid
+      # token that another process stored. We should skip our own HTTP refresh.
       let(:store_data) do
-        { refresh_token: "stored_refresh_token", access_token: "fresh", expires_at: (Time.now + 3600).iso8601 }
+        { refresh_token: "stored_refresh_token", access_token: "old", expires_at: (Time.now - 60).iso8601 }
+      end
+      let(:on_reload) do
+        { access_token: "other_process_token", expires_at: (Time.now + 3600).iso8601 }
       end
 
       it "acquires the lock, reloads, and skips the HTTP refresh" do
@@ -179,6 +190,31 @@ RSpec.describe GreenhouseIo::V3::PartnerTokenManager do
         expect(locking_store.lock_calls).to eq(1)
         expect(locking_store.reload_calls).to eq(1)
         expect(WebMock).not_to have_requested(:post, "https://auth.greenhouse.io/token")
+      end
+    end
+
+    context "when force_refresh! is called with an unexpired but rejected token (401 path)" do
+      # token_valid? is true (not expired) but Greenhouse rejected it, so the
+      # 401 retry calls force_refresh!. reload does NOT change the token (no
+      # other process refreshed), so we must actually refresh -- not skip.
+      let(:store_data) do
+        { refresh_token: "stored_refresh_token", access_token: "rejected_but_unexpired", expires_at: (Time.now + 3600).iso8601 }
+      end
+
+      before do
+        stub_request(:post, "https://auth.greenhouse.io/token")
+          .with(body: { "grant_type" => "refresh_token", "refresh_token" => "stored_refresh_token" })
+          .to_return(
+            status: 200,
+            body: { access_token: "refreshed_token", refresh_token: "rotated", expires_at: (Time.now + 3600).iso8601 }.to_json,
+            headers: { "Content-Type" => "application/json" }
+          )
+      end
+
+      it "actually refreshes despite the token being unexpired" do
+        manager.force_refresh!
+        expect(WebMock).to have_requested(:post, "https://auth.greenhouse.io/token")
+        expect(locking_store[:access_token]).to eq("refreshed_token")
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,6 +27,9 @@ VCR.configure do |config|
     auth = interaction.request.headers['Authorization']&.first
     auth if auth&.start_with?('Bearer ')
   end
+  config.filter_sensitive_data('<V3_REFRESH_TOKEN>') do |interaction|
+    interaction.response.body[/"refresh_token":"([^"]+)"/, 1]
+  end
   config.default_cassette_options = { record: ENV.fetch('VCR_RECORD_MODE', 'once').to_sym }
   config.configure_rspec_metadata!
 end


### PR DESCRIPTION
Extract shared HTTP/API behavior into V3::BaseClient and add a Partner integration client alongside the existing Custom integration client.

- V3::BaseClient: shared request/retry/rate-limit behavior; subclasses set @token_manager in #initialize
- Rename V3::Client -> V3::CustomClient, V3::TokenManager -> V3::CustomTokenManager (behavior unchanged)
- V3::PartnerClient / V3::PartnerTokenManager: refresh-token-only auth with no client_credentials fallback; raises ReauthorizationRequired when the refresh token is expired/invalid
- Add GreenhouseIo::ReauthorizationRequired error
- Provide V3::Client / V3::TokenManager back-compat aliases

## Description of the change

> Description here
> Link to error service URL (if applicable)

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] Schema changes (if applicable) will play nicely with "rolling" deploy mechanism
- [ ] All UX vectors have been considered (desktop app, Chrome extension, responsive view)
- [ ] The code changed/added does not introduce security vulnerabilities

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] At least one other engineer confirms that schema changes (if applicable) will play nicely with "rolling" deploy mechanism
- [ ] At least one other engineer confirms that all UX vectors have been considered (desktop app, Chrome extension, responsive view)
- [ ] At least one other engineer has confirmed that the code changed/added will not introduce security vulnerabilities
- [ ] Issue from task tracker has a link to this pull request
