### PR TITLE
Add v3 webhook management + PATCH support

### DIFF
--- a/lib/greenhouse_io/api.rb
+++ b/lib/greenhouse_io/api.rb
@@ -8,6 +8,10 @@ module GreenhouseIo
       self.class.post(url, options)
     end
 
+    def patch_response(url, options)
+      self.class.patch(url, options)
+    end
+
     def parse_json(response)
       JSON.parse(response.body, symbolize_names: GreenhouseIo.configuration.symbolize_keys)
     end

--- a/lib/greenhouse_io/v3/base_client.rb
+++ b/lib/greenhouse_io/v3/base_client.rb
@@ -86,62 +86,11 @@ module GreenhouseIo
       end
 
       def post_to_harvest_api(url, body, headers = {})
-        response = post_response(url, {
-          body: JSON.dump(body),
-          headers: json_headers(headers)
-        })
-
-        set_headers_info(response.headers)
-
-        if response.success?
-          parse_json(response)
-        elsif response.code == 401 && !@token_refreshed_this_request
-          @token_refreshed_this_request = true
-          @token_manager.force_refresh!
-          begin
-            post_to_harvest_api(url, body, headers)
-          ensure
-            @token_refreshed_this_request = false
-          end
-        else
-          raise GreenhouseIo::Error.new(response.code)
-        end
+        write_to_harvest_api(:post, url, body, headers)
       end
 
       def patch_to_harvest_api(url, body, headers = {})
-        response = patch_response(url, {
-          body: JSON.dump(body),
-          headers: json_headers(headers)
-        })
-
-        set_headers_info(response.headers)
-
-        if response.success?
-          parse_json(response)
-        elsif response.code == 401 && !@token_refreshed_this_request
-          @token_refreshed_this_request = true
-          @token_manager.force_refresh!
-          begin
-            patch_to_harvest_api(url, body, headers)
-          ensure
-            @token_refreshed_this_request = false
-          end
-        else
-          raise GreenhouseIo::Error.new(response.code)
-        end
-      end
-
-      # Webhook management (partners-exclusive). See https://harvestdocs.greenhouse.io.
-      def list_webhooks(options = {})
-        get_from_harvest_api('/webhooks', options)
-      end
-
-      def create_webhook(attributes)
-        post_to_harvest_api('/webhooks', attributes)
-      end
-
-      def update_webhook(id, attributes)
-        patch_to_harvest_api("/webhooks#{path_id(id)}", attributes)
+        write_to_harvest_api(:patch, url, body, headers)
       end
 
       def with_retries(retry_options = { on: { GreenhouseIo::Error => RETRIABLE_ERRORS_REGEXP } })
@@ -162,6 +111,31 @@ module GreenhouseIo
       private
 
       attr_accessor :using_with_retries
+
+      # Shared write path for POST/PATCH: JSON-encode the body, attach bearer + JSON headers, and
+      # refresh-and-retry once on a 401 (re-dispatching the same verb).
+      def write_to_harvest_api(verb, url, body, headers)
+        response = send("#{verb}_response", url, {
+          body: JSON.dump(body),
+          headers: json_headers(headers)
+        })
+
+        set_headers_info(response.headers)
+
+        if response.success?
+          parse_json(response)
+        elsif response.code == 401 && !@token_refreshed_this_request
+          @token_refreshed_this_request = true
+          @token_manager.force_refresh!
+          begin
+            write_to_harvest_api(verb, url, body, headers)
+          ensure
+            @token_refreshed_this_request = false
+          end
+        else
+          raise GreenhouseIo::Error.new(response.code)
+        end
+      end
 
       def bearer_auth_header
         { "Authorization" => "Bearer #{@token_manager.access_token}" }

--- a/lib/greenhouse_io/v3/base_client.rb
+++ b/lib/greenhouse_io/v3/base_client.rb
@@ -88,7 +88,7 @@ module GreenhouseIo
       def post_to_harvest_api(url, body, headers = {})
         response = post_response(url, {
           body: JSON.dump(body),
-          headers: bearer_auth_header.merge(headers)
+          headers: json_headers(headers)
         })
 
         set_headers_info(response.headers)
@@ -106,6 +106,42 @@ module GreenhouseIo
         else
           raise GreenhouseIo::Error.new(response.code)
         end
+      end
+
+      def patch_to_harvest_api(url, body, headers = {})
+        response = patch_response(url, {
+          body: JSON.dump(body),
+          headers: json_headers(headers)
+        })
+
+        set_headers_info(response.headers)
+
+        if response.success?
+          parse_json(response)
+        elsif response.code == 401 && !@token_refreshed_this_request
+          @token_refreshed_this_request = true
+          @token_manager.force_refresh!
+          begin
+            patch_to_harvest_api(url, body, headers)
+          ensure
+            @token_refreshed_this_request = false
+          end
+        else
+          raise GreenhouseIo::Error.new(response.code)
+        end
+      end
+
+      # Webhook management (partners-exclusive). See https://harvestdocs.greenhouse.io.
+      def list_webhooks(options = {})
+        get_from_harvest_api('/webhooks', options)
+      end
+
+      def create_webhook(attributes)
+        post_to_harvest_api('/webhooks', attributes)
+      end
+
+      def update_webhook(id, attributes)
+        patch_to_harvest_api("/webhooks#{path_id(id)}", attributes)
       end
 
       def with_retries(retry_options = { on: { GreenhouseIo::Error => RETRIABLE_ERRORS_REGEXP } })
@@ -129,6 +165,11 @@ module GreenhouseIo
 
       def bearer_auth_header
         { "Authorization" => "Bearer #{@token_manager.access_token}" }
+      end
+
+      # Bearer auth + JSON content type for write requests. An explicit header wins if supplied.
+      def json_headers(headers)
+        bearer_auth_header.merge("Content-Type" => "application/json").merge(headers)
       end
 
       def get_resource(resource_class, options, dehydrate_after_iteration: true)

--- a/lib/greenhouse_io/v3/partner_client.rb
+++ b/lib/greenhouse_io/v3/partner_client.rb
@@ -18,6 +18,20 @@ module GreenhouseIo
           token_store: token_store
         )
       end
+
+      # Webhook management is exclusive to partner integrations, so it lives here rather than on
+      # BaseClient (custom-integration clients must not expose these). See https://harvestdocs.greenhouse.io.
+      def list_webhooks(options = {})
+        get_from_harvest_api('/webhooks', options)
+      end
+
+      def create_webhook(attributes)
+        post_to_harvest_api('/webhooks', attributes)
+      end
+
+      def update_webhook(id, attributes)
+        patch_to_harvest_api("/webhooks#{path_id(id)}", attributes)
+      end
     end
   end
 end

--- a/lib/greenhouse_io/version.rb
+++ b/lib/greenhouse_io/version.rb
@@ -1,3 +1,3 @@
 module GreenhouseIo
-  VERSION = "3.8.3-grayscale"
+  VERSION = "3.8.4-grayscale"
 end

--- a/spec/greenhouse_io/v3/base_client_spec.rb
+++ b/spec/greenhouse_io/v3/base_client_spec.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# BaseClient is abstract (subclasses set @token_manager); exercise its shared HTTP behavior
+# through PartnerClient with a valid cached token so no auth round-trip happens.
+RSpec.describe GreenhouseIo::V3::BaseClient do
+  let(:token_store) do
+    { access_token: "test_bearer_token", expires_at: (Time.now + 3600).iso8601 }
+  end
+
+  let(:client) do
+    GreenhouseIo::V3::PartnerClient.new(
+      client_id: "test_client_id",
+      client_secret: "test_client_secret",
+      token_store: token_store
+    )
+  end
+
+  let(:response_headers) do
+    { "Content-Type" => "application/json", "x-ratelimit-limit" => "50", "x-ratelimit-remaining" => "49", "link" => "" }
+  end
+
+  describe "#post_to_harvest_api" do
+    it "sends Content-Type: application/json" do
+      stub = stub_request(:post, "https://harvest.greenhouse.io/v3/webhooks")
+             .with(headers: { "Content-Type" => "application/json", "Authorization" => "Bearer test_bearer_token" })
+             .to_return(status: 201, body: JSON.dump("id" => 1), headers: response_headers)
+
+      client.post_to_harvest_api("/webhooks", { event_action_type: "hire_candidate" })
+
+      expect(stub).to have_been_requested
+    end
+
+    it "lets an explicit header override the default Content-Type" do
+      stub = stub_request(:post, "https://harvest.greenhouse.io/v3/webhooks")
+             .with(headers: { "Content-Type" => "application/xml" })
+             .to_return(status: 201, body: JSON.dump("id" => 1), headers: response_headers)
+
+      client.post_to_harvest_api("/webhooks", {}, { "Content-Type" => "application/xml" })
+
+      expect(stub).to have_been_requested
+    end
+  end
+
+  describe "#patch_to_harvest_api" do
+    it "issues a PATCH with Bearer auth and JSON content type" do
+      stub = stub_request(:patch, "https://harvest.greenhouse.io/v3/webhooks/1")
+             .with(headers: { "Content-Type" => "application/json", "Authorization" => "Bearer test_bearer_token" })
+             .to_return(status: 200, body: JSON.dump("id" => 1, "deactivated" => false), headers: response_headers)
+
+      result = client.patch_to_harvest_api("/webhooks/1", { deactivated: false })
+
+      expect(stub).to have_been_requested
+      expect(result["deactivated"]).to be(false)
+    end
+
+    it "refreshes the token and retries once on a 401" do
+      token_store[:refresh_token] = "stored_refresh"
+
+      stub_request(:patch, "https://harvest.greenhouse.io/v3/webhooks/1")
+        .with(headers: { "Authorization" => "Bearer test_bearer_token" })
+        .to_return(status: 401, body: '{"message":"Unauthorized"}', headers: response_headers)
+
+      stub_request(:post, "https://auth.greenhouse.io/token")
+        .to_return(
+          status: 200,
+          body: JSON.dump("access_token" => "refreshed_token", "refresh_token" => "rotated",
+                          "expires_at" => (Time.now + 3600).iso8601),
+          headers: { "Content-Type" => "application/json" }
+        )
+
+      retried = stub_request(:patch, "https://harvest.greenhouse.io/v3/webhooks/1")
+                .with(headers: { "Authorization" => "Bearer refreshed_token" })
+                .to_return(status: 200, body: JSON.dump("id" => 1, "deactivated" => false), headers: response_headers)
+
+      client.patch_to_harvest_api("/webhooks/1", { deactivated: false })
+
+      expect(retried).to have_been_requested
+    end
+  end
+
+  describe "webhook management" do
+    describe "#create_webhook" do
+      it "POSTs the attributes to /webhooks" do
+        stub = stub_request(:post, "https://harvest.greenhouse.io/v3/webhooks")
+               .with(
+                 headers: { "Content-Type" => "application/json" },
+                 body: { event_action_type: "hire_candidate", deactivated: true }.to_json
+               )
+               .to_return(status: 201, body: JSON.dump("id" => 5, "deactivated" => true), headers: response_headers)
+
+        result = client.create_webhook(event_action_type: "hire_candidate", deactivated: true)
+
+        expect(stub).to have_been_requested
+        expect(result["id"]).to eq(5)
+      end
+    end
+
+    describe "#update_webhook" do
+      it "PATCHes /webhooks/{id} with the attributes" do
+        stub = stub_request(:patch, "https://harvest.greenhouse.io/v3/webhooks/5")
+               .with(body: { deactivated: false }.to_json)
+               .to_return(status: 200, body: JSON.dump("id" => 5, "deactivated" => false), headers: response_headers)
+
+        client.update_webhook(5, deactivated: false)
+
+        expect(stub).to have_been_requested
+      end
+    end
+
+    describe "#list_webhooks" do
+      it "GETs /webhooks with the given filters" do
+        stub = stub_request(:get, "https://harvest.greenhouse.io/v3/webhooks")
+               .with(query: { event_action_type: "hire_candidate" })
+               .to_return(status: 200, body: JSON.dump([{ "id" => 5 }]), headers: response_headers)
+
+        result = client.list_webhooks(event_action_type: "hire_candidate")
+
+        expect(stub).to have_been_requested
+        expect(result.first["id"]).to eq(5)
+      end
+    end
+  end
+end

--- a/spec/greenhouse_io/v3/base_client_spec.rb
+++ b/spec/greenhouse_io/v3/base_client_spec.rb
@@ -79,47 +79,4 @@ RSpec.describe GreenhouseIo::V3::BaseClient do
       expect(retried).to have_been_requested
     end
   end
-
-  describe "webhook management" do
-    describe "#create_webhook" do
-      it "POSTs the attributes to /webhooks" do
-        stub = stub_request(:post, "https://harvest.greenhouse.io/v3/webhooks")
-               .with(
-                 headers: { "Content-Type" => "application/json" },
-                 body: { event_action_type: "hire_candidate", deactivated: true }.to_json
-               )
-               .to_return(status: 201, body: JSON.dump("id" => 5, "deactivated" => true), headers: response_headers)
-
-        result = client.create_webhook(event_action_type: "hire_candidate", deactivated: true)
-
-        expect(stub).to have_been_requested
-        expect(result["id"]).to eq(5)
-      end
-    end
-
-    describe "#update_webhook" do
-      it "PATCHes /webhooks/{id} with the attributes" do
-        stub = stub_request(:patch, "https://harvest.greenhouse.io/v3/webhooks/5")
-               .with(body: { deactivated: false }.to_json)
-               .to_return(status: 200, body: JSON.dump("id" => 5, "deactivated" => false), headers: response_headers)
-
-        client.update_webhook(5, deactivated: false)
-
-        expect(stub).to have_been_requested
-      end
-    end
-
-    describe "#list_webhooks" do
-      it "GETs /webhooks with the given filters" do
-        stub = stub_request(:get, "https://harvest.greenhouse.io/v3/webhooks")
-               .with(query: { event_action_type: "hire_candidate" })
-               .to_return(status: 200, body: JSON.dump([{ "id" => 5 }]), headers: response_headers)
-
-        result = client.list_webhooks(event_action_type: "hire_candidate")
-
-        expect(stub).to have_been_requested
-        expect(result.first["id"]).to eq(5)
-      end
-    end
-  end
 end

--- a/spec/greenhouse_io/v3/partner_client_spec.rb
+++ b/spec/greenhouse_io/v3/partner_client_spec.rb
@@ -118,4 +118,47 @@ RSpec.describe GreenhouseIo::V3::PartnerClient do
       end
     end
   end
+
+  describe "webhook management" do
+    describe "#create_webhook" do
+      it "POSTs the attributes to /webhooks" do
+        stub = stub_request(:post, "https://harvest.greenhouse.io/v3/webhooks")
+               .with(
+                 headers: { "Content-Type" => "application/json" },
+                 body: { event_action_type: "hire_candidate", deactivated: true }.to_json
+               )
+               .to_return(status: 201, body: JSON.dump("id" => 5, "deactivated" => true), headers: default_response_headers)
+
+        result = client.create_webhook(event_action_type: "hire_candidate", deactivated: true)
+
+        expect(stub).to have_been_requested
+        expect(result["id"]).to eq(5)
+      end
+    end
+
+    describe "#update_webhook" do
+      it "PATCHes /webhooks/{id} with the attributes" do
+        stub = stub_request(:patch, "https://harvest.greenhouse.io/v3/webhooks/5")
+               .with(body: { deactivated: false }.to_json)
+               .to_return(status: 200, body: JSON.dump("id" => 5, "deactivated" => false), headers: default_response_headers)
+
+        client.update_webhook(5, deactivated: false)
+
+        expect(stub).to have_been_requested
+      end
+    end
+
+    describe "#list_webhooks" do
+      it "GETs /webhooks with the given filters" do
+        stub = stub_request(:get, "https://harvest.greenhouse.io/v3/webhooks")
+               .with(query: { event_action_type: "hire_candidate" })
+               .to_return(status: 200, body: JSON.dump([{ "id" => 5 }]), headers: default_response_headers)
+
+        result = client.list_webhooks(event_action_type: "hire_candidate")
+
+        expect(stub).to have_been_requested
+        expect(result.first["id"]).to eq(5)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Adds the partner webhook CRUD needed by cATs RC-3260, plus PATCH support and a Content-Type fix on write requests.

- `list_webhooks` (GET /v3/webhooks), `create_webhook` (POST /v3/webhooks), `update_webhook(id, attrs)` (PATCH /v3/webhooks/{id}) on `PartnerClient` — webhooks are partner-only, so they're gated to that client (not exposed on `BaseClient`/`CustomClient`).
- `patch_to_harvest_api` + `API#patch_response` — no PATCH support existed before. POST/PATCH share a private `write_to_harvest_api` helper so the 401-refresh-retry logic lives in one place.
- `json_headers`: send `Content-Type: application/json` on POST/PATCH (write requests were sent without it); explicit header still overrides.
- Version bump to 3.8.4-grayscale.

## Testing

`base_client_spec.rb`: content-type default + override, PATCH round-trip, PATCH 401 -> refresh -> retry. `partner_client_spec.rb`: create/update/list_webhooks. Full v3 suite green (pre-existing `integration_spec.rb` live-token failure unrelated).

## Notes

Consumed by cATs RC-3260. Merge + tag `v3.8.4-grayscale`, then the cATs PR points its Gemfile at the tag.
