### PR TITLE
Fix v3 interviews hitting v1 /scheduled_interviews endpoint

### DIFF
--- a/lib/greenhouse_io/api/interview.rb
+++ b/lib/greenhouse_io/api/interview.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'greenhouse_io/api/resource'
+
+module GreenhouseIo
+  # Harvest v3 "Interviews" (renamed from v1 "Scheduled Interviews"). The v3 endpoint is
+  #   `/interviews`, distinct from v1's `/scheduled_interviews` (see ScheduledInterview).
+  class Interview < Resource
+    DEFAULT_ENDPOINT = "/interviews"
+  end
+end

--- a/lib/greenhouse_io/api/interview_collection.rb
+++ b/lib/greenhouse_io/api/interview_collection.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'greenhouse_io/api/interview'
+require 'greenhouse_io/api/resource_collection'
+
+module GreenhouseIo
+  # Collection for Harvest v3 `/interviews`. Unlike v1's ScheduledInterviewCollection, v3 has no
+  #   nested `/applications/:id/interviews` route — callers filter by the `application_ids` query
+  #   param instead — so this is a plain collection over the flat endpoint.
+  class InterviewCollection < ResourceCollection
+    def initialize(*args, **kw_args)
+      kw_args.merge!(resource_class: Interview)
+      super
+    end
+  end
+end

--- a/lib/greenhouse_io/v3/base_client.rb
+++ b/lib/greenhouse_io/v3/base_client.rb
@@ -2,7 +2,7 @@
 
 require 'greenhouse_io/api/application_collection'
 require 'greenhouse_io/api/candidate_collection'
-require 'greenhouse_io/api/scheduled_interview_collection'
+require 'greenhouse_io/api/interview_collection'
 require 'greenhouse_io/api/job_collection'
 require 'greenhouse_io/api/job_post_collection'
 require 'greenhouse_io/api/job_stage_collection'
@@ -62,7 +62,7 @@ module GreenhouseIo
 
       def interviews(options = {})
         kw_args, params = normalize_options(options)
-        get_resource(GreenhouseIo::ScheduledInterviewCollection, params, **kw_args)
+        get_resource(GreenhouseIo::InterviewCollection, params, **kw_args)
       end
 
       def get_from_harvest_api(url, options = {})

--- a/spec/greenhouse_io/v3/custom_client_spec.rb
+++ b/spec/greenhouse_io/v3/custom_client_spec.rb
@@ -49,6 +49,25 @@ RSpec.describe GreenhouseIo::V3::CustomClient do
     end
   end
 
+  describe "#interviews" do
+    it "returns an InterviewCollection" do
+      result = client.interviews
+      expect(result).to be_a(GreenhouseIo::InterviewCollection)
+    end
+
+    # Regression guard: v3 interviews must hit /v3/interviews, NOT v1's /scheduled_interviews.
+    #   The shared v1 ScheduledInterviewCollection defaults to /scheduled_interviews, which 404s on v3.
+    it "requests the v3 /interviews endpoint" do
+      stub = stub_request(:get, "https://harvest.greenhouse.io/v3/interviews?per_page=1")
+        .with(headers: { "Authorization" => "Bearer test_bearer_token" })
+        .to_return(status: 200, body: JSON.dump([{ "id" => 1 }]), headers: default_response_headers)
+
+      client.interviews(per_page: 1).first
+
+      expect(stub).to have_been_requested
+    end
+  end
+
   describe "#get_from_harvest_api" do
     context "successful request" do
       it "makes a GET with Bearer auth" do


### PR DESCRIPTION
## Description of the change

The v3 client's `#interviews` method routed through the shared v1 `ScheduledInterviewCollection`. When no `application_id` is given (the polling case), that collection leaves `endpoint` nil, so `ResourceCollection` falls back to `ScheduledInterview::DEFAULT_ENDPOINT` = `/scheduled_interviews` — the **v1** path — which returns **404** on the v3 API.

### Fix

- Add a dedicated v3 `Interview` resource with `DEFAULT_ENDPOINT = "/interviews"`.
- Add a plain `InterviewCollection` over that endpoint (v3 has no nested `/applications/:id/interviews` route — callers filter via the `application_ids` query param).
- Route v3 `BaseClient#interviews` through `InterviewCollection`.

v1's `ScheduledInterviewCollection` / `/scheduled_interviews` is left completely untouched, so `Client#scheduled_interviews` is unaffected.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] Schema changes (if applicable) will play nicely with "rolling" deploy mechanism
- [ ] All UX vectors have been considered (desktop app, Chrome extension, responsive view)
- [ ] The code changed/added does not introduce security vulnerabilities

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] At least one other engineer confirms that schema changes (if applicable) will play nicely with "rolling" deploy mechanism
- [ ] At least one other engineer confirms that all UX vectors have been considered (desktop app, Chrome extension, responsive view)
- [ ] At least one other engineer has confirmed that the code changed/added will not introduce security vulnerabilities
- [ ] Issue from task tracker has a link to this pull request
